### PR TITLE
Imports settings and precompile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vsc-fracas",
-  "version": "0.1.4",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "Wonderstorm",
     "displayName": "Fracas",
     "description": "Syntax highlighting, code navigation, document formatting, and REPL support for the Fracas and Racket programming languages",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "enableProposedApi": true,
     "enabledApiProposals": [
         "textSearchProvider",
@@ -112,8 +112,13 @@
                 },
                 "vscode-fracas.general.racketCollectionPaths": {
                     "type": "array",
-                    "items": { "type": "string" },
-                    "default": ["C:\\proj\\ws\\tdp1\\wslib", "C:\\proj\\ws\\tdp1\\fracas\\lib"],
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "C:\\proj\\ws\\tdp1\\wslib",
+                        "C:\\proj\\ws\\tdp1\\fracas\\lib"
+                    ],
                     "markdownDescription": "A list of paths to search for Racket collections."
                 },
                 "vscode-fracas.trace.server": {

--- a/package.json
+++ b/package.json
@@ -103,22 +103,20 @@
                 "vscode-fracas.general.projectDir": {
                     "type": "string",
                     "default": "C:\\proj\\ws\\tdp1\\wslib",
-                    "markdownDescription": "Specifies the racket working directory and base directory for collection paths."
-                },
-                "vscode-fracas.general.REPLRacketPath": {
-                    "type": "string",
-                    "default": "C:\\Progra~1\\Racket\\racket.EXE",
-                    "markdownDescription": "Specifies the path to the `racket` executable used to open the REPL and run the file."
+                    "markdownDescription": "Specifies the racket working directory and base directory for collection paths.",
+                    "order": 0
                 },
                 "vscode-fracas.general.racketPath": {
                     "type": "string",
                     "default": "C:\\Progra~1\\Racket\\racket.EXE",
-                    "markdownDescription": "Specifies the path to the `racket` executable used to launch the Racket language server."
+                    "markdownDescription": "Specifies the path to the `racket` executable used to launch the Racket language server.",
+                    "order": 1
                 },
-                "vscode-fracas.general.ninjaPath": {
+                "vscode-fracas.general.REPLRacketPath": {
                     "type": "string",
-                    "default": "ninja",
-                    "markdownDescription": "Specifies the path to the `ninja` executable used to precompile racket files."
+                    "default": "C:\\Progra~1\\Racket\\racket.EXE",
+                    "markdownDescription": "Specifies the path to the `racket` executable used to open the REPL and run the file.",
+                    "order": 2
                 },
                 "vscode-fracas.general.racketCollectionPaths": {
                     "type": "array",
@@ -129,7 +127,14 @@
                         ".",
                         "..\\fracas\\lib"
                     ],
-                    "markdownDescription": "A list of paths to search for Racket collections."
+                    "markdownDescription": "A list of paths to search for Racket collections.",
+                    "order": 3
+                },
+                "vscode-fracas.general.ninjaPath": {
+                    "type": "string",
+                    "default": "ninja",
+                    "markdownDescription": "Specifies the path to the `ninja` executable used to precompile racket files.",
+                    "order": 4
                 },
                 "vscode-fracas.trace.server": {
                     "scope": "window",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
         "configuration": {
             "title": "Fracas",
             "properties": {
+                "vscode-fracas.general.projectDir": {
+                    "type": "string",
+                    "default": "C:\\proj\\ws\\tdp1\\wslib",
+                    "markdownDescription": "Specifies the racket working directory and base directory for collection paths."
+                },
                 "vscode-fracas.general.REPLRacketPath": {
                     "type": "string",
                     "default": "C:\\Progra~1\\Racket\\racket.EXE",
@@ -110,14 +115,19 @@
                     "default": "C:\\Progra~1\\Racket\\racket.EXE",
                     "markdownDescription": "Specifies the path to the `racket` executable used to launch the Racket language server."
                 },
+                "vscode-fracas.general.ninjaPath": {
+                    "type": "string",
+                    "default": "ninja",
+                    "markdownDescription": "Specifies the path to the `ninja` executable used to precompile racket files."
+                },
                 "vscode-fracas.general.racketCollectionPaths": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     },
                     "default": [
-                        "C:\\proj\\ws\\tdp1\\wslib",
-                        "C:\\proj\\ws\\tdp1\\fracas\\lib"
+                        ".",
+                        "..\\fracas\\lib"
                     ],
                     "markdownDescription": "A list of paths to search for Racket collections."
                 },
@@ -202,6 +212,10 @@
             {
                 "command": "vscode-fracas.recompileFracasObject",
                 "title": "Fracas: Recompile Previous Object"
+            },
+            {
+                "command": "vscode-fracas.precompileFracasFile",
+                "title": "Fracas: Precompile File"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
                 },
                 "vscode-fracas.general.racketCollectionPaths": {
                     "type": "array",
+                    "items": { "type": "string" },
                     "default": ["C:\\proj\\ws\\tdp1\\wslib", "C:\\proj\\ws\\tdp1\\fracas\\lib"],
                     "markdownDescription": "A list of paths to search for Racket collections."
                 },

--- a/package.json
+++ b/package.json
@@ -102,13 +102,18 @@
             "properties": {
                 "vscode-fracas.general.REPLRacketPath": {
                     "type": "string",
-                    "default": "C:\\Progra~1\\Racket\\racket.EXE -q -U -S C:\\proj\\ws\\tdp1\\fracas\\lib -S C:\\proj\\ws\\tdp1\\wslib",
+                    "default": "C:\\Progra~1\\Racket\\racket.EXE",
                     "markdownDescription": "Specifies the path to the `racket` executable used to open the REPL and run the file."
                 },
                 "vscode-fracas.general.racketPath": {
                     "type": "string",
                     "default": "C:\\Progra~1\\Racket\\racket.EXE",
                     "markdownDescription": "Specifies the path to the `racket` executable used to launch the Racket language server."
+                },
+                "vscode-fracas.general.racketCollectionPaths": {
+                    "type": "array",
+                    "default": ["C:\\proj\\ws\\tdp1\\wslib", "C:\\proj\\ws\\tdp1\\fracas\\lib"],
+                    "markdownDescription": "A list of paths to search for Racket collections."
                 },
                 "vscode-fracas.trace.server": {
                     "scope": "window",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -97,7 +97,7 @@ export function precompileFracasFile(frcDoc: vscode.TextDocument | undefined = u
         // invoke ninja to precompile the fracas file
         const ninjaCmd = `${ninja} -f ./build/build_precompile.ninja ${zoFile}`;
         console.log(ninjaCmd);
-        execShell(ninjaCmd, "C:/proj/ws/tdp1/wslib");
+        execShell(ninjaCmd);
     }
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,7 +21,7 @@ export function helpWithSelectedSymbol(): void {
 
 export function runInTerminal(terminals: Map<string, vscode.Terminal>): void {
     withFilePath((filePath: string) => {
-        withRacket((racket: string) => {
+        withRacket((racket: string, racketArgs: string[]) => {
             let terminal;
             if (
                 vscode.workspace
@@ -32,15 +32,15 @@ export function runInTerminal(terminals: Map<string, vscode.Terminal>): void {
             } else {
                 terminal = getOrDefault(terminals, filePath, () => createTerminal(filePath));
             }
-            runFileInTerminal(racket, filePath, terminal);
+            runFileInTerminal(racket, racketArgs, filePath, terminal);
         });
     });
 }
 
 export function loadInRepl(repls: Map<string, vscode.Terminal>): void {
     withFilePath((filePath: string) => {
-        withRacket((racket: string) => {
-            const repl = getOrDefault(repls, filePath, () => createRepl(fileName(filePath), racket));
+        withRacket((racket: string, racketArgs: string[]) => {
+            const repl = getOrDefault(repls, filePath, () => createRepl(fileName(filePath), racket, racketArgs));
             loadFileInRepl(filePath, repl);
         });
     });
@@ -54,11 +54,11 @@ export async function executeSelection(repls: Map<string, vscode.Terminal>): Pro
 }
 
 export async function compileFracasObject(filePath: string, fracasObject: string): Promise<void> {
-    const racket = getRacket();
+    const [racket, racketArgs] = getRacket();
     if (fracasObject && filePath && racket) {
         vscode.window.activeTextEditor?.document?.save();
         const cmd = `(require fracas/make-asset-json) (enter! (file "${filePath}")) (define-asset-impl: #:value ${fracasObject} #:value-name (quote ${fracasObject}) #:key (key: ${fracasObject}))`;
-        execShell(`${racket} -e "${cmd.replace(/"/g, '\\"')}"`);
+        execShell(`${racket} ${racketArgs.join(" ")} -e "${cmd.replace(/"/g, '\\"')}"`);
     }
 }
 
@@ -76,8 +76,8 @@ export async function recompileFracasObject(): Promise<void> {
 
 export function openRepl(repls: Map<string, vscode.Terminal>): void {
     withFilePath((filePath: string) => {
-        withRacket((racket: string) => {
-            const repl = getOrDefault(repls, filePath, () => createRepl(fileName(filePath), racket));
+        withRacket((racket: string, racketArgs: string[]) => {
+            const repl = getOrDefault(repls, filePath, () => createRepl(fileName(filePath), racket, racketArgs));
             repl.show();
         });
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,6 +92,9 @@ export function activate(context: vscode.ExtensionContext): void {
     const repls: Map<string, vscode.Terminal> = new Map();
 
     vscode.workspace.onDidChangeConfiguration(configurationChanged);
+    
+    // precompile fracas every time a file is saved
+    vscode.workspace.onDidSaveTextDocument((document) => com.precompileFracasFile(document));
 
     vscode.window.onDidCloseTerminal((terminal) => {
         terminals.forEach((val, key) => val === terminal && terminals.delete(key) && val.dispose());
@@ -102,6 +105,7 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         reg("compileSelectedFracasObject", () => com.compileSelectedFracasObject()),
         reg("recompileFracasObject", () => com.recompileFracasObject()),
+        reg("precompileFracasFile", () => com.precompileFracasFile()),
         reg("loadFileInRepl", () => com.loadInRepl(repls)),
         reg("runFile", () => com.runInTerminal(terminals)),
         reg("executeSelectionInRepl", () => com.executeSelection(repls)),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,10 +21,10 @@ export function deactivate(): Promise<void> {
 }
 
 function setupLSP() {
-    withRacket((racket: string) => {
+    withRacket((racket: string, racketArgs: string[]) => {
         const executable = {
             command: racket,
-            args: ["--lib", "racket-langserver"],
+            args: racketArgs.concat("--lib", "racket-langserver"),
         };
 
         // If the extension is launched in debug mode then the debug server options are used
@@ -47,6 +47,8 @@ function setupLSP() {
                 protocol2Code: (str) => vscode.Uri.parse(str),
             },
         };
+
+        console.log(`Starting language server with ${executable.command} ${executable.args.join(" ")}`);
 
         // Create the language client and start the client.
         langClient = new LanguageClient(

--- a/src/fracas/syntax.ts
+++ b/src/fracas/syntax.ts
@@ -51,7 +51,6 @@ export class FracasDefinition {
     readonly completionKind: vscode.CompletionItemKind;
 
     constructor(definition: vscode.Location, symbol: string, kind: FracasDefinitionKind) {
-        ;
         this.location = definition;
         this.symbol = symbol;
         this.kind = kind;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,17 @@
 import * as vscode from "vscode";
 import * as cp from "child_process";
 
-export function execShell(cmd: string) : Promise<string> {
+export function execShell(cmd: string, workingDir: string | undefined = undefined) : Promise<string> {
     return new Promise<string>((resolve, reject) => {
-        cp.exec(cmd, (err, out) => {
-            if (err) {
-                vscode.window.showErrorMessage(err.message);
-                return reject(err);
-            }
-            return resolve(out);
-        });
+        cp.exec(cmd, 
+            { cwd: workingDir || vscode.workspace.getConfiguration("vscode-fracas.general").get<string>("projectDir") },
+            (err, out) => {
+                if (err) {
+                    vscode.window.showErrorMessage(err.message);
+                    return reject(err);
+                }
+                return resolve(out);
+            });
     });
 }
 
@@ -47,12 +49,15 @@ export function getRacket(server = false) : [string,string[]] {
             "No Racket executable specified. Please add the path to the Racket executable in settings",
         );
     }
+    const projectDir = vscode.workspace
+        .getConfiguration("vscode-fracas.general")
+        .get<string>("projectDir") || [];
     const collectPaths = vscode.workspace
         .getConfiguration("vscode-fracas.general")
         .get<string[]>("racketCollectionPaths") || [];
     const racketArgs = [];
     for (const path of collectPaths) {
-        racketArgs.push("-S", path);
+        racketArgs.push("-S", normalizeFilePath(`${projectDir}\\${path}`));
     }
     return [racket, racketArgs];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,22 +37,29 @@ export function delay(ms: number) : Promise<void> {
     return new Promise( resolve => setTimeout(resolve, ms) );
 }
 
-export function getRacket(server = false) : string | undefined {
+export function getRacket(server = false) : [string,string[]] {
     const racketPathKey = server ? "racketPath" : "REPLRacketPath";
     const racket = vscode.workspace
         .getConfiguration("vscode-fracas.general")
-        .get<string>(racketPathKey);
+        .get<string>(racketPathKey) || "racket";
     if (!racket) {
         vscode.window.showErrorMessage(
             "No Racket executable specified. Please add the path to the Racket executable in settings",
         );
     }
-    return racket;
+    const collectPaths = vscode.workspace
+        .getConfiguration("vscode-fracas.general")
+        .get<string[]>("racketCollectionPaths") || [];
+    const racketArgs = [];
+    for (const path of collectPaths) {
+        racketArgs.push("-S", path);
+    }
+    return [racket, racketArgs];
 }
 
-export function withRacket(func: (racketPath: string) => void, server = false): void {
-    const racket = getRacket(server);
+export function withRacket(func: (racketPath: string, racketArgs: string[]) => void, server = false): void {
+    const [racket, racketArgs] = getRacket(server);
     if (racket) {
-        func(racket);
+        func(racket, racketArgs);
     }
 }


### PR DESCRIPTION
- FRC files are automatically precompiled when you save. I _think_ this should fix the JSON export failures.
- The racket language server is now launched with the proper collection paths (wslib and fracas/lib) so that it can properly resolve `import`s.
- The collection paths and project directory are now configurable settings.