### PR TITLE
Fix extension crash, add unit tests, and add navigate to definition support for named function parameters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,9 @@
 			"request": "launch",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index",
+                "--disable-extensions",
+				"${workspaceFolder}/src/test/fixture"
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/test/**/*.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vsc-fracas",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "Wonderstorm",
     "displayName": "Fracas",
     "description": "Syntax highlighting, code navigation, document formatting, and REPL support for the Fracas and Racket programming languages",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "enableProposedApi": true,
     "enabledApiProposals": [
         "textSearchProvider",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,3 +1,4 @@
+import * as fs from "fs";
 import { parse } from "path";
 import * as vscode from "vscode";
 import { getOrDefault } from "./containers";
@@ -94,10 +95,16 @@ export function precompileFracasFile(frcDoc: vscode.TextDocument | undefined = u
         const upperRoot = frcPath.root.toUpperCase(); // ninja requires that the drive letter be uppercase
         const zoFile = `${upperRoot}${frcPath.dir.substring(upperRoot.length)}/compiled/${frcPath.name}_frc.zo`;
 
-        // invoke ninja to precompile the fracas file
-        const ninjaCmd = `${ninja} -f ./build/build_precompile.ninja ${zoFile}`;
-        console.log(ninjaCmd);
-        execShell(ninjaCmd);
+        // If the precompiled zo file exists, invoke ninja to update it
+        fs.access(zoFile, fs.constants.R_OK, (err) => {
+            if (err) {
+                console.log(`Skipping precompile of ${zoFile} because it does not exist`);
+            } else {
+                const ninjaCmd = `${ninja} -f ./build/build_precompile.ninja ${zoFile}`;
+                console.log(ninjaCmd);
+                execShell(ninjaCmd);
+            }
+        });
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,7 @@ function setupLSP() {
         // Options to control the language client
         const clientOptions: LanguageClientOptions = {
             // Register the server for racket documents
-            documentSelector: [{ scheme: "file", language: "racket" }, { scheme: "file", language: "fracas" }],
+            documentSelector: [{ scheme: "file", language: "racket" }],
             synchronize: {
                 // Notify the server about file changes to '.clientrc files contained in the workspace
                 fileEvents: vscode.workspace.createFileSystemWatcher("**/.clientrc"),

--- a/src/fracas/definition-provider.ts
+++ b/src/fracas/definition-provider.ts
@@ -1,26 +1,18 @@
 import * as vscode from 'vscode'; // The module 'vscode' contains the VS Code extensibility API
 import {
-    getSelectedSymbol,
-} from '../editor-lib';
-import {
     findDefinition,
 } from './syntax';
 
 export class FracasDefinitionProvider implements vscode.DefinitionProvider {
     public provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken)
         : Promise<vscode.Definition> {
-        const symbol = getSelectedSymbol();
-        if (!symbol) {
-            vscode.window.showErrorMessage("No symbol found at cursor position");
-            return Promise.resolve([]);
-        }
-
-        return this._findDefinition(symbol, token);
+        return this._findDefinition(document, position, token);
     }
 
-    private async _findDefinition(symbol: string, token: vscode.CancellationToken)
-        : Promise<vscode.Location[]> {
-        const results = await findDefinition(symbol, token);
+    private async _findDefinition(
+        document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken
+    ): Promise<vscode.Location[]> {
+        const results = await findDefinition(document, position, token);
         return results.map(result => result.location);
     }
 }

--- a/src/fracas/reference-provider.ts
+++ b/src/fracas/reference-provider.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode'; // The module 'vscode' contains the VS Code extensibility API
-import { getSelectedSymbol } from '../editor-lib';
 import { findReferences } from './syntax';
 
 export class FracasReferenceProvider implements vscode.ReferenceProvider {
@@ -7,15 +6,9 @@ export class FracasReferenceProvider implements vscode.ReferenceProvider {
         document: vscode.TextDocument,
         position: vscode.Position,
         context: vscode.ReferenceContext,
-        token: vscode.CancellationToken)
-        : Promise<vscode.Location[]> {
-        const symbol = getSelectedSymbol();
-        if (!symbol) {
-            vscode.window.showErrorMessage("No symbol found at cursor position");
-            return Promise.resolve([]);
-        }
-
-        return findReferences(symbol, token);
+        token: vscode.CancellationToken
+    ): Promise<vscode.Location[]> {
+        return findReferences(document, position, token);
     }
 
 }

--- a/src/fracas/syntax.ts
+++ b/src/fracas/syntax.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import { flatten, mapAsync } from '../containers';
-import { findTextInFiles, getRange, searchBackward } from '../editor-lib';
+import { findTextInFiles, getRange, getSelectedSymbol, resolveSymbol, searchBackward } from '../editor-lib';
 
-export const FIELD_PREFIX = '#:';
+export const FIELD_OR_PARAM_PREFIX = '#:';
 export const RX_CHARS_OPEN_PAREN = '\\(|\\{|\\[';
 export const RX_CHARS_CLOSE_PAREN = '\\)|\\}|\\]';
 export const RX_CHARS_SPACE = '\\s|\\r|\\n';
@@ -178,7 +178,7 @@ export function completionKind(fracasKind: FracasDefinitionKind): vscode.Complet
         case (FracasDefinitionKind.define):
             return vscode.CompletionItemKind.Variable;
         case (FracasDefinitionKind.field):
-            return vscode.CompletionItemKind.Variable;
+            return vscode.CompletionItemKind.Field;
         case (FracasDefinitionKind.unknown):
         default:
             return vscode.CompletionItemKind.Unit;
@@ -409,8 +409,8 @@ function _rangesAtScope(
     return ranges;
 }
 
-export async function findEnclosingDefine(uri: vscode.Uri, pos: vscode.Position)
-    : Promise<FracasDefinition | null> {
+export async function findEnclosingDefine(uri: vscode.Uri, pos: vscode.Position
+): Promise<FracasDefinition | null> {
     const searchRx = new RegExp(_anyDefineRx(), "g");
     const result = await searchBackward(uri, pos, searchRx);
     if (result) {
@@ -421,8 +421,8 @@ export async function findEnclosingDefine(uri: vscode.Uri, pos: vscode.Position)
     return null;
 }
 
-export async function findEnclosingConstructor(document: vscode.TextDocument, pos: vscode.Position)
-    : Promise<[loc: vscode.Location, typeName: string] | null> {
+export async function findEnclosingConstructor(document: vscode.TextDocument, pos: vscode.Position
+): Promise<[loc: vscode.Location, typeName: string] | null> {
     const openParen = findOpenBracket(document, pos);
     const searchRx = new RegExp(_anyConstructorRx());
     const result = searchRx.exec(document.getText(new vscode.Range(openParen, pos)));
@@ -434,8 +434,8 @@ export async function findEnclosingConstructor(document: vscode.TextDocument, po
     return null;
 }
 
-export async function findEnclosingEnumOrMask(document: vscode.TextDocument, pos: vscode.Position)
-    : Promise<FracasDefinition | null> {
+export async function findEnclosingEnumOrMask(document: vscode.TextDocument, pos: vscode.Position
+): Promise<FracasDefinition | null> {
     const openParen = findOpenBracket(document, pos);
     const searchRx = new RegExp(_anyMaskOrEnumRx());
     const result = searchRx.exec(document.getText(new vscode.Range(openParen, pos)));
@@ -448,8 +448,9 @@ export async function findEnclosingEnumOrMask(document: vscode.TextDocument, pos
     return null;
 }
 
-export async function isWithinVariant(uri: vscode.Uri, pos: vscode.Position, variantName: string)
-    : Promise<boolean> {
+export async function isWithinVariant(
+    uri: vscode.Uri, pos: vscode.Position, variantName: string
+): Promise<boolean> {
     const fracasDef = await findEnclosingDefine(uri, pos);
     return fracasDef !== null
         && fracasDef.kind === FracasDefinitionKind.variant
@@ -458,9 +459,9 @@ export async function isWithinVariant(uri: vscode.Uri, pos: vscode.Position, var
 
 export async function findTypeDefinition(
     typeName: string,
-    token: vscode.CancellationToken,
-    searchKind = SearchKind.wholeMatch)
-    : Promise<FracasDefinition[]> {
+    token?: vscode.CancellationToken,
+    searchKind = SearchKind.wholeMatch
+): Promise<FracasDefinition[]> {
     typeName = typeName.replace(/(^-)|(-$)/g, ''); // trim leading/trailing hyphen
     const defineRxStr = _anyDefineSymbolRx(typeName, searchKind);
     return _findDefinition(defineRxStr, token);
@@ -468,26 +469,26 @@ export async function findTypeDefinition(
 
 export async function findEnumDefinition(
     typeName: string,
-    token: vscode.CancellationToken,
-    searchKind = SearchKind.wholeMatch)
-    : Promise<FracasDefinition[]> {
+    token?: vscode.CancellationToken,
+    searchKind = SearchKind.wholeMatch
+): Promise<FracasDefinition[]> {
     const defineRxStr = _anyEnumSymbolRx(typeName, searchKind);
     return _findDefinition(defineRxStr, token);
 }
 
 export async function findMaskDefinition(
     typeName: string,
-    token: vscode.CancellationToken,
-    searchKind = SearchKind.wholeMatch)
-    : Promise<FracasDefinition[]> {
+    token?: vscode.CancellationToken,
+    searchKind = SearchKind.wholeMatch
+): Promise<FracasDefinition[]> {
     const defineRxStr = _anyMaskSymbolRx(typeName, searchKind);
     return _findDefinition(defineRxStr, token);
 }
 
 async function _findDefinition(
     defineRxStr: string,
-    token: vscode.CancellationToken)
-    : Promise<FracasDefinition[]> {
+    token?: vscode.CancellationToken
+): Promise<FracasDefinition[]> {
     // search for an explicit define-xxx matching the token, e.g., given "module-db" find "(define-type module-db"
     const textMatches = await findTextInFiles(defineRxStr, token);
     console.debug(`Found ${textMatches.length} matches for ${defineRxStr}`);
@@ -502,9 +503,9 @@ async function _findDefinition(
 
 export async function findVariantOptionDefinition(
     qualifiedVariant: string,
-    token: vscode.CancellationToken,
-    searchKind = SearchKind.wholeMatch)
-    : Promise<FracasDefinition[]> {
+    token?: vscode.CancellationToken,
+    searchKind = SearchKind.wholeMatch
+): Promise<FracasDefinition[]> {
     // given a fully qualified "action-movement-modifier-add" find "(movement-modifier-add ... )"
     const variantOptionRxStr = _variantOptionRx(qualifiedVariant, searchKind);
     const variantRx = new RegExp(variantOptionRxStr);
@@ -537,72 +538,94 @@ export async function findVariantOptionDefinition(
 }
 
 export async function findFieldDefinition(
-    fieldName: string,
-    token: vscode.CancellationToken,
-    searchKind: SearchKind = SearchKind.wholeMatch)
-    : Promise<FracasDefinition[]> {
-    if (fieldName.startsWith(FIELD_PREFIX)) {
-        const activeEditor = vscode.window.activeTextEditor;
-        if (activeEditor) {
-            // find the constructor in which this field is declared
-            const constructorMatch = await findEnclosingConstructor(activeEditor.document, activeEditor.selection.start);
-            if (constructorMatch) {
-                // find the type definition matching the constructor
-                const [_, typeName] = constructorMatch;
-                let typeDefs = await findTypeDefinition(typeName, token);
-                if (typeDefs.length === 0) {
-                    typeDefs = await findVariantOptionDefinition(typeName, token);
-                }
-
-                // find the field declarations in the type definition
-                const fieldDecls = await mapAsync(typeDefs, async typeDef => {
-                    return await findMembers(typeDef, token, fieldName.substring(FIELD_PREFIX.length), searchKind);
-                });
-                return flatten(fieldDecls);
-            }
-        }
+    referencingDocument?: vscode.TextDocument,
+    referencingSelection?: vscode.Range,
+    token?: vscode.CancellationToken,
+    searchKind: SearchKind = SearchKind.wholeMatch
+): Promise<FracasDefinition[]> {
+    const activeEditor = vscode.window.activeTextEditor;
+    referencingDocument = referencingDocument || activeEditor?.document;
+    referencingSelection = referencingSelection || activeEditor?.selection;
+    if (!referencingDocument || !referencingSelection) {
+        return Promise.resolve([]);
     }
 
-    return Promise.resolve([]);
+    const fieldName = getSelectedSymbol(referencingDocument, referencingSelection);
+    if (!fieldName.startsWith(FIELD_OR_PARAM_PREFIX)) {
+        return Promise.resolve([]);
+    }
+
+    // find the constructor in which this field is declared
+    const constructorMatch = await findEnclosingConstructor(referencingDocument, referencingSelection.start);
+    if (!constructorMatch) {
+        return Promise.resolve([]);
+    }
+
+    // find the type definition matching the constructor
+    const [_, typeName] = constructorMatch;
+    let typeDefs = await findTypeDefinition(typeName, token);
+    if (typeDefs.length === 0) {
+        typeDefs = await findVariantOptionDefinition(typeName, token);
+    }
+
+    // find the field declarations in the type definition
+    const fieldDecls = await mapAsync(typeDefs, async typeDef => {
+        return await findMembers(typeDef, token, fieldName.substring(FIELD_OR_PARAM_PREFIX.length), searchKind);
+    });
+    return flatten(fieldDecls);
 }
 
 export async function findDefinition(
-    symbol: string,
-    token: vscode.CancellationToken,
-    searchKind: SearchKind = SearchKind.wholeMatch)
-    : Promise<FracasDefinition[]> {
-    let results: FracasDefinition[] = await findFieldDefinition(symbol, token, searchKind);
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token?: vscode.CancellationToken,
+    searchKind: SearchKind = SearchKind.wholeMatch
+): Promise<FracasDefinition[]> {
+    let results: FracasDefinition[] = await findFieldDefinition(
+        document, new vscode.Range(position, position), token, searchKind);
+    if (results.length > 0) {
+        return results;
+    }
+
+    const symbol = getSelectedSymbol(document, position);
 
     // search for an explicit define-xxx matching the token, e.g., given "module-db" find "(define-type module-db"
-    if (results.length === 0) {
-        results = await findTypeDefinition(symbol, token, searchKind);
+    results = await findTypeDefinition(symbol, token, searchKind);
+    if (results.length > 0) {
+        return results;
     }
 
     // search for a variant option matching the symbol
-    if (results.length === 0) {
-        // given a fully qualified "action-movement-modifier-add" find "(movement-modifier-add ... )"
-        results = await findVariantOptionDefinition(symbol, token, searchKind);
-    }
+    // given a fully qualified "action-movement-modifier-add" find "(movement-modifier-add ... )"
+    results = await findVariantOptionDefinition(symbol, token, searchKind);
 
     return results;
 }
 
-export async function findReferences(symbol: string, token: vscode.CancellationToken)
-    : Promise<vscode.Location[]> {
-    // Do a dumb search for all text matching the symbol
+export async function findReferences(
+    referencingDocument?: vscode.TextDocument,
+    referencingPosition?: vscode.Position,
+    token?: vscode.CancellationToken
+): Promise<vscode.Location[]> {
+    const activeEditor = vscode.window.activeTextEditor;
+    referencingDocument = referencingDocument || activeEditor?.document;
+    referencingPosition = referencingPosition || activeEditor?.selection.anchor;
+    if (!referencingDocument || !referencingPosition) {
+        return [];
+    }
+    
+    const symbol = getSelectedSymbol(referencingDocument, referencingPosition);
+        // Do a dumb search for all text matching the symbol
     const symbolRx = _anySymbolRx(symbol);
     const results = await findTextInFiles(symbolRx, token);
 
     // if the symbol is part of a variant, search for the full variant option name. E.g. if the cursor is
     // on (combat-focus ()) within (define-variant targeting-gather ...), search for "targeting-gather-combat-focus"
-    const activeEditor = vscode.window.activeTextEditor;
-    if (activeEditor) {
-        const fracasDef = await findEnclosingDefine(activeEditor.document.uri, activeEditor.selection.start);
-        if (fracasDef !== null && fracasDef.kind === FracasDefinitionKind.variant) {
-            const variantOption = `${fracasDef.symbol}-${symbol}`;
-            const variantResults = await findTextInFiles(_anySymbolRx(variantOption), token);
-            results.push(...variantResults);
-        }
+    const fracasDef = await findEnclosingDefine(referencingDocument.uri, referencingPosition);
+    if (fracasDef?.kind === FracasDefinitionKind.variant) {
+        const variantOption = `${fracasDef.symbol}-${symbol}`;
+        const variantResults = await findTextInFiles(_anySymbolRx(variantOption), token);
+        results.push(...variantResults);
     }
 
     // convert results from TextSearchMatch to Location
@@ -611,8 +634,9 @@ export async function findReferences(symbol: string, token: vscode.CancellationT
     return links;
 }
 
-export async function findDocumentSymbols(uri: vscode.Uri, token: vscode.CancellationToken)
-    : Promise<vscode.DocumentSymbol[]> {
+export async function findDocumentSymbols(
+    uri: vscode.Uri, token?: vscode.CancellationToken
+): Promise<vscode.DocumentSymbol[]> {
     const defineRxStr = _anyDefineRx();
     const defineRx = new RegExp(defineRxStr);
     const textMatches = await findTextInFiles(defineRxStr, token, uri.fsPath);
@@ -634,29 +658,32 @@ export async function findDocumentSymbols(uri: vscode.Uri, token: vscode.Cancell
 export async function findCompletions(
     document: vscode.TextDocument,
     position: vscode.Position,
-    token: vscode.CancellationToken)
-    : Promise<vscode.CompletionItem[] | null> {
+    token?: vscode.CancellationToken
+): Promise<vscode.CompletionItem[] | null> {
     // get the word at the cursor
-    const wordRange = document.getWordRangeAtPosition(position, /[#:\w\-+*.]+/);
+    const resolvedSymbol = resolveSymbol(document, position);
 
     // don't try to complete until at least three characters are typed
-    if (wordRange && position.character - wordRange.start.character >= 3) {
+    if (resolvedSymbol && position.character - resolvedSymbol.range.start.character >= 3) {
         // truncate the partial word at the cursor position
-        const symbol = document.getText(new vscode.Range(wordRange.start, position));
+        const symbolRange = new vscode.Range(resolvedSymbol.range.start, position);
+        const symbol = resolvedSymbol.document.getText(symbolRange);
 
         // try to auto-complete a member field name
-        if (symbol.startsWith(FIELD_PREFIX)) {
+        if (symbol.startsWith(FIELD_OR_PARAM_PREFIX)) {
             // do a partial match of all field definitions matching the symbol under the cursor
-            const fieldDefs = await findFieldDefinition(symbol, token, SearchKind.partialMatch);
+            const fieldDefs = await findFieldDefinition(
+                resolvedSymbol.document, symbolRange, token, SearchKind.partialMatch);
             if (fieldDefs.length > 0) {
-                const fieldCompletions = await _toCompletionItems(fieldDefs, FIELD_PREFIX, wordRange);
+                const fieldCompletions = await _toCompletionItems(
+                    fieldDefs, FIELD_OR_PARAM_PREFIX, resolvedSymbol.range);
                 console.debug(`Found ${fieldCompletions.length} fields for ${symbol}`);
                 return fieldCompletions;
             }
         } else {
             // if the symbol is the beginning of (mask foo thing... or (enum bar thing...
             // then try to auto-complete from the enum/mask definition
-            const enclosingEnum = await findEnclosingEnumOrMask(document, position);
+            const enclosingEnum = await findEnclosingEnumOrMask(resolvedSymbol.document, position);
             if (enclosingEnum) {
                 // find the definition of the enum/mask
                 const enumDefs = enclosingEnum.kind === FracasDefinitionKind.enum ?
@@ -666,12 +693,12 @@ export async function findCompletions(
                 await mapAsync(enumDefs, async enumDef => {
                     // add matching enum values to the completion list
                     const enumMembers = await findMembers(enumDef, token, symbol, SearchKind.partialMatch);
-                    const oneEnumCompletions = await _toCompletionItems(enumMembers, '', wordRange);
+                    const oneEnumCompletions = await _toCompletionItems(enumMembers, '', resolvedSymbol.range);
                     enumCompletions.push(...oneEnumCompletions);
 
                     // add the enum name to the completion list if it matches.
                     if (enumDef.symbol.startsWith(symbol)) {
-                        const enumNameCompletion = await _toCompletionItems([enumDef], '', wordRange);
+                        const enumNameCompletion = await _toCompletionItems([enumDef], '', resolvedSymbol.range);
                         enumCompletions.push(...enumNameCompletion);
                     }
                 });
@@ -685,14 +712,14 @@ export async function findCompletions(
                 const typeDefs = await findTypeDefinition(symbol, token, SearchKind.partialMatch);
                 if (typeDefs.length > 0) {
                     // add the type definitions as completion items, e.g. "targeting-ga" => "targeting-gather"
-                    const typeCompletions = await _toCompletionItems(typeDefs, '', wordRange);
+                    const typeCompletions = await _toCompletionItems(typeDefs, '', resolvedSymbol.range);
 
                     // also suggest variant options as completions for matching variant types.
                     // e.g., targeting-gat => targeting-gather-self, targeting-gather-saved-actor, etc.
                     const variantDefs = typeDefs.filter(x => x.kind === FracasDefinitionKind.variant);
                     const variantCompletions = flatten(await mapAsync(variantDefs, async variantDef => {
                         const options = await findMembers(variantDef, token);
-                        const optionCompletions = await _toCompletionItems(options, `${variantDef.symbol}-`, wordRange);
+                        const optionCompletions = await _toCompletionItems(options, `${variantDef.symbol}-`, resolvedSymbol.range);
                         return optionCompletions;
                     }));
 
@@ -703,7 +730,7 @@ export async function findCompletions(
 
                 // find variant options matching the symbol, e.g. targeting-gather-sa => targeting-gather-saved-actor
                 const variantOptions = await findVariantOptionDefinition(symbol, token, SearchKind.partialMatch);
-                const variantCompletions = await _toCompletionItems(variantOptions, '', wordRange);
+                const variantCompletions = await _toCompletionItems(variantOptions, '', resolvedSymbol.range);
                 console.debug(`Found ${variantCompletions.length} variant options for ${symbol}`);
 
                 completionItems.push(...variantCompletions);
@@ -717,8 +744,9 @@ export async function findCompletions(
     return null;
 }
 
-async function _toCompletionItems(definitions: FracasDefinition[], prefix: string, replaceRange: vscode.Range)
-    : Promise<vscode.CompletionItem[]> {
+async function _toCompletionItems(
+    definitions: FracasDefinition[], prefix: string, replaceRange: vscode.Range
+): Promise<vscode.CompletionItem[]> {
     const completionItems: vscode.CompletionItem[] = await mapAsync(definitions, async definition => {
         const item = new vscode.CompletionItem(`${prefix}${definition.symbol}`, definition.completionKind);
         item.documentation = await findComment(definition.location.uri, definition.location.range.start);
@@ -730,10 +758,10 @@ async function _toCompletionItems(definitions: FracasDefinition[], prefix: strin
 
 export async function findMembers(
     fracasDef: FracasDefinition,
-    token: vscode.CancellationToken,
+    token?: vscode.CancellationToken,
     memberName: string | null = null,
-    searchKind: SearchKind = SearchKind.wholeMatch)
-    : Promise<FracasDefinition[]> {
+    searchKind: SearchKind = SearchKind.wholeMatch
+): Promise<FracasDefinition[]> {
     const document = await vscode.workspace.openTextDocument(fracasDef.location.uri);
     const scopeNestingDepth = _memberScopeDepth(fracasDef.kind);
     const fieldRx = _memberDeclRx(fracasDef.kind, memberName || '', searchKind);
@@ -744,16 +772,17 @@ async function _findMembers(
     document: vscode.TextDocument,
     position: vscode.Position,
     fieldRx: RegExp,
-    scopeNestingDepth: number)
-    : Promise<FracasDefinition[]> {
+    scopeNestingDepth: number
+): Promise<FracasDefinition[]> {
     const members: FracasDefinition[] = [];
     const ranges = await _rangesAtScope(document, position, scopeNestingDepth);
     for (const range of ranges) {
         const expr = document.getText(range);
         for (let match = fieldRx.exec(expr); match; match = fieldRx.global ? fieldRx.exec(expr) : null) {
             const [_, fieldName] = match;
-            const memberPos = document.positionAt(document.offsetAt(range.start) + match.index);
-            const loc = new vscode.Location(document.uri, memberPos);
+            const memberStart = document.positionAt(document.offsetAt(range.start) + match.index);
+            const memberEnd = memberStart.translate({characterDelta: fieldName.length});
+            const loc = new vscode.Location(document.uri, new vscode.Range(memberStart, memberEnd));
             members.push(new FracasDefinition(loc, fieldName, FracasDefinitionKind.field));
         }
     }

--- a/src/test/fixture/ability-action-defines.frc
+++ b/src/test/fixture/ability-action-defines.frc
@@ -1,0 +1,51 @@
+#lang fracas
+
+;; Actions are always performed in the order they appear in the arrays below
+(define-variant action-block
+  #:u-data-asset
+  (targeted ;; apply actions to a targeted set of actors ;; FIND action-block-targeted
+   (
+    (name key #:default *key-none* #:constructor name->id) ;; ID for this action block  - usually left blank, unless there is a specific animation event that is intended to run these actions (see `ability-state-data.anim-actions`)
+    (targeting targeting-data) ;; gathers actors upon which the other Action types operate on
+    (actions (array action) #:default '()) ;; run no matter how many actors are found by the targeting check; context: any actors found by the targeting
+    (miss-actions (array action) #:default '()) ;; run only if no actors are found by the targeting check; context: owner (if targeting finds no actors)
+    (found-actions (array action) #:default '()) ;; run only if > 0 actors are found by the targeting check; context: any actors found by the targeting
+    (condition ability-condition #:default (ability-condition-true-value:)) ;; actions are only run if conditions evaluates to true
+    )
+   )
+  (no-target ;; apply actions without specifying a target ;; FIND action-block-no-target
+   (
+    (name key #:default *key-none* #:constructor name->id)
+    (actions (array action) #:default '())
+    (condition ability-condition #:default (ability-condition-true-value:)) ;; actions are only run if conditions evaluates to true
+    )
+   )
+  )
+
+(define (action-camera-shake: #:data shake-spec
+                              #:key (key *key-none*)
+                              #:net-playback-mode (net-playback-mode *net-local-client*)
+                              #:scale (scale 1.0)
+
+                              #:world-space (world-space #f)
+                              #:inner-radius (inner-radius 0)
+                              #:outer-radius (outer-radius 0)
+                              #:falloff (falloff 1.0)
+                              )
+  (action-camera-shake-start:
+   #:key key
+   #:data
+   (camera-shake-data:
+    #:shake-spec shake-spec
+    #:params
+    (shake-params:
+     #:net-playback-mode net-playback-mode
+     #:scale scale
+     #:world-space world-space
+     #:inner-radius inner-radius
+     #:outer-radius outer-radius
+     #:falloff falloff)
+    )
+   )
+  )
+  

--- a/src/test/fixture/ability.frc
+++ b/src/test/fixture/ability.frc
@@ -1,0 +1,48 @@
+#lang fracas
+
+(define ability-npc-creature-magmacrab-explode-detonate-actions
+  (list
+   (action-block-targeted: ;; This is an option of the action-block variant
+    #:targeting ability-npc-creature-magmacrab-explode-targeting
+    #:found-actions
+    (list
+     (action-damage: #:data ability-npc-creature-magmacrab-explode-damage)
+     )
+    )
+   (action-block-targeted:
+    #:targeting *targeting-self*
+    #:found-actions
+    (list
+     (action-status-effect-remove: #:key status-effect-key-splat-warning)
+     (action-cue-assets:
+      asset-actionable-border-crystal-explosive-vfx
+      asset-actionable-border-crystal-explosive-audio
+      asset-npc-creature-magmacrab-death-splat-vfx
+      #:attach-data (attach-to-actor-world-space:)
+      )
+     (action-damage: #:data ability-npc-creature-magmacrab-explode-damage-self)
+     )
+    )
+   )
+  )
+  
+(define ability-npc-creature-magmacrab-carrier-goo-proj-hit-actions
+  (list
+   (action-block-targeted:
+    #:targeting *targeting-contextual*
+    #:found-actions
+    (list
+     (action-cue-tag: *tag-cue.character.shared.hitspark.light*)
+     )
+    )
+   (action-block-targeted:
+    #:targeting *targeting-contextual-enemies*
+    #:found-actions
+    (list
+     (action-status-effect-add: #:key status-effect-key-slow)
+     (action-camera-shake: #:net-playback-mode *net-owning-client* #:data *camera-shake-small*)
+     )
+    )
+   *self-destruct*
+   )
+  )

--- a/src/test/fixture/reward.frc
+++ b/src/test/fixture/reward.frc
@@ -1,0 +1,7 @@
+#lang fracas
+(define-type range-int #:export-constructor ((min int) (max int)))
+(define-type reward
+    (
+        (item-key key)
+        (count range-int #:default (range-int: #:min 1 #:max 1))))
+(reward: #:count (range-int: #:min 1 #:max 1) #:item-key 'item-material-sun-small))

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -23,7 +23,7 @@ async function showFracasDocument(
 suite("Extension Test Suite", () => {
     vscode.window.showInformationMessage("Start all tests.");
 
-    const rewardFrc = path.join((vscode.workspace.workspaceFolders || [])[0].uri.fsPath, 'reward.frc')
+    const rewardFrc = path.join((vscode.workspace.workspaceFolders || [])[0].uri.fsPath, 'reward.frc');
 
     const rewardCountTextRange = new vscode.Range(6, 9, 6, 16); // selection around "#:count"
 
@@ -34,7 +34,7 @@ suite("Extension Test Suite", () => {
     });
 
     test("getSelectedSymbol returns selection range", async () => {
-        await showFracasDocument(rewardFrc, new vscode.Range(6, 12, 6, 16));
+        await showFracasDocument(rewardFrc, new vscode.Range(6, 12, 6, 16)); // selection around "ount"
         const symbol = getSelectedSymbol();
         assert.strictEqual(symbol, "ount");
     });
@@ -47,5 +47,15 @@ suite("Extension Test Suite", () => {
         assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Field, "field completion kind is not 'field'");
         assert.strictEqual(defs[0].symbol, "count");
         assert.deepStrictEqual(defs[0].location.range, new vscode.Range(5, 9, 5, 14), "location of definition is not correct");
+    });
+
+    test("findDefinition resolves a type def", async () => {
+        const { document } = await showFracasDocument(rewardFrc); // cursor within "(range-int: ..."
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(6, 21));
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.type, "type definition kind is not 'type'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Struct, "type completion kind is not 'Struct'");
+        assert.strictEqual(defs[0].symbol, "range-int");
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(1, 13, 1, 22), "location of definition is not correct");
     });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -20,12 +20,13 @@ async function showFracasDocument(
     return { document, editor };
 }
 
-suite("Extension Test Suite", () => {
-    vscode.window.showInformationMessage("Start all tests.");
+const testFixtureDir = (vscode.workspace.workspaceFolders || [])[0].uri.fsPath;
+const rewardFrc = path.join(testFixtureDir, 'reward.frc');
+const abilityFrc = path.join(testFixtureDir, 'ability.frc');
+const abilityActionDefinesFrc = path.join(testFixtureDir, 'ability-action-defines.frc');
 
-    const rewardFrc = path.join((vscode.workspace.workspaceFolders || [])[0].uri.fsPath, 'reward.frc');
-
-    const rewardCountTextRange = new vscode.Range(6, 9, 6, 16); // selection around "#:count"
+suite("Editor Lib Tests", () => {
+    vscode.window.showInformationMessage("Start editor lib tests.");
 
     test("getSelectedSymbol returns word under cursor", async () => {
         await showFracasDocument(rewardFrc, new vscode.Range(6, 9, 6, 9));
@@ -38,24 +39,64 @@ suite("Extension Test Suite", () => {
         const symbol = getSelectedSymbol();
         assert.strictEqual(symbol, "ount");
     });
+});
+
+suite("Find Definition Tests", () => {
+    vscode.window.showInformationMessage("Start findDefinition tests.");
+    
+    test("findDefinition resolves a named parameter", async () => {
+        const { document } = await showFracasDocument(abilityFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(42, 38)); // cursor within "#:net-playback-mode"
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.keyword, "type definition kind is not 'parameter'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Keyword, "type completion kind is not 'Keyword'");
+        assert.strictEqual(defs[0].symbol, "net-playback-mode");
+        assert.strictEqual(defs[0].location.uri.fsPath, abilityActionDefinesFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(26, 32, 26, 49), "location of named parameter is not correct");
+    });
 
     test("findDefinition resolves a field def", async () => {
         const { document } = await showFracasDocument(rewardFrc);
-        const defs: FracasDefinition[] = await findDefinition(document, rewardCountTextRange.start);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(6, 9)); // selection at "#:count");
         assert.strictEqual(defs.length, 1, "single definition not found");
-        assert.strictEqual(defs[0].kind, FracasDefinitionKind.field, "field definition kind is not 'field'");
-        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Field, "field completion kind is not 'field'");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.keyword, "field definition kind is not 'field'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Keyword, "field completion kind is not 'Keyword'");
         assert.strictEqual(defs[0].symbol, "count");
+        assert.strictEqual(defs[0].location.uri.fsPath, rewardFrc);
         assert.deepStrictEqual(defs[0].location.range, new vscode.Range(5, 9, 5, 14), "location of definition is not correct");
     });
 
     test("findDefinition resolves a type def", async () => {
-        const { document } = await showFracasDocument(rewardFrc); // cursor within "(range-int: ..."
-        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(6, 21));
+        const { document } = await showFracasDocument(rewardFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(6, 21)); // cursor within "(range-int: ..."
         assert.strictEqual(defs.length, 1, "single definition not found");
         assert.strictEqual(defs[0].kind, FracasDefinitionKind.type, "type definition kind is not 'type'");
         assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Struct, "type completion kind is not 'Struct'");
         assert.strictEqual(defs[0].symbol, "range-int");
+        assert.strictEqual(defs[0].location.uri.fsPath, rewardFrc);
         assert.deepStrictEqual(defs[0].location.range, new vscode.Range(1, 13, 1, 22), "location of definition is not correct");
     });
+
+    test("findDefinition resolves a variant", async () => {
+        const { document } = await showFracasDocument(abilityFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(4, 62)); // cursor within "action-block"
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.variant, "type definition kind is not 'variant'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Struct, "type completion kind is not 'Struct'");
+        assert.strictEqual(defs[0].symbol, "action-block");
+        assert.strictEqual(defs[0].location.uri.fsPath, abilityActionDefinesFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(3, 16, 3, 28), "location of definition is not correct");
+    });
+
+    test("findDefinition resolves a variant option", async () => {
+        const { document } = await showFracasDocument(abilityFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(4, 12)); // cursor within "action-block-targeted:"
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.variantOption, "type definition kind is not 'variantOption'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Struct, "type completion kind is not 'Struct'");
+        assert.strictEqual(defs[0].symbol, "action-block-targeted");
+        assert.strictEqual(defs[0].location.uri.fsPath, abilityActionDefinesFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(5, 3, 5, 11), "location of definition is not correct");
+    });
+
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,15 +1,51 @@
 import * as assert from "assert";
+import path = require("path");
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from "vscode";
+import { getSelectedSymbol } from "../../editor-lib";
+import { 
+    findDefinition,
+    FracasDefinition, 
+    FracasDefinitionKind 
+} from "../../fracas/syntax";
 // import * as myExtension from '../../extension';
+
+async function showFracasDocument(
+    fileName: string, selection?: vscode.Range
+): Promise<{ document: vscode.TextDocument, editor: vscode.TextEditor }> {
+    const document = await vscode.workspace.openTextDocument(fileName);
+    const editor = await vscode.window.showTextDocument(document, {selection});
+    return { document, editor };
+}
 
 suite("Extension Test Suite", () => {
     vscode.window.showInformationMessage("Start all tests.");
 
-    test("Sample test", () => {
-        assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-        assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+    const rewardFrc = path.join((vscode.workspace.workspaceFolders || [])[0].uri.fsPath, 'reward.frc')
+
+    const rewardCountTextRange = new vscode.Range(6, 9, 6, 16); // selection around "#:count"
+
+    test("getSelectedSymbol returns word under cursor", async () => {
+        await showFracasDocument(rewardFrc, new vscode.Range(6, 9, 6, 9));
+        const symbol = getSelectedSymbol();
+        assert.strictEqual(symbol, "#:count");
+    });
+
+    test("getSelectedSymbol returns selection range", async () => {
+        await showFracasDocument(rewardFrc, new vscode.Range(6, 12, 6, 16));
+        const symbol = getSelectedSymbol();
+        assert.strictEqual(symbol, "ount");
+    });
+
+    test("findDefinition resolves a field def", async () => {
+        const { document } = await showFracasDocument(rewardFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, rewardCountTextRange.start);
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.field, "field definition kind is not 'field'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Field, "field completion kind is not 'field'");
+        assert.strictEqual(defs[0].symbol, "count");
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(5, 9, 5, 14), "location of definition is not correct");
     });
 });


### PR DESCRIPTION
This PR adds unit tests for the major categories of `findDefinition` (types, variants, variant options, etc.), and also adds support for using `F12` on named parameters.

This also disables the racket language server for fracas files, which was causing the extension to crash. The language server was only really useful to format fracas documents. A future PR will restore support for `.frc` file formatting.