### PR TITLE
F12 to enum/mask type definition and members, auto-complete enum/mask type names and member names, auto-complete keywords

### DIFF
--- a/src/containers.ts
+++ b/src/containers.ts
@@ -31,3 +31,18 @@ export async function asyncGetOrDefault<K, V>(map: Map<K, V>, key: K, getDefault
     map.set(key, def);
     return def;
 }
+
+/**
+ * Remove duplicate items from an array.
+ * @param array An array of items possibly containing duplicates.
+ * @param keyfn A callback function that returns a key for each item in the array.
+ * @returns An array of items with duplicates removed.
+ */
+export function uniqBy<K, V>(array: V[], keyfn: (value: V) => K): V[] {
+    return [
+        ...new Map(
+            array.map(x => [keyfn(x), x])
+        ).values()
+    ];
+}
+

--- a/src/editor-lib.ts
+++ b/src/editor-lib.ts
@@ -58,12 +58,12 @@ export async function findTextInFiles(
 }
 
 export function getSelectedSymbol(
-    document?: vscode.TextDocument, where?: vscode.Range | vscode.Position
+    document?: vscode.TextDocument, where?: vscode.Range | vscode.Position, stripTrailingColon = false
 ): string {
     const resolvedSymbol = resolveSymbol(document, where);
     if (resolvedSymbol) {
         let word = resolvedSymbol.document.getText(resolvedSymbol.range);
-        if (word.endsWith(':')) { // strip trailing ':' for fracas constructors (hacky)
+        if (stripTrailingColon && word.endsWith(':')) { // strip trailing ':' for fracas constructors (hacky)
             word = word.substring(0, word.length - 1);
         }
         return word;

--- a/src/fracas/syntax.ts
+++ b/src/fracas/syntax.ts
@@ -606,7 +606,7 @@ export async function findKeywordDefinition(
         return [];
     }
 
-    const keyword = referencingDocument.getText(documentSelection);
+    const keyword = getSelectedSymbol(referencingDocument, documentSelection);
     if (!keyword.startsWith(KEYWORD_PREFIX)) {
         return [];
     }
@@ -693,7 +693,7 @@ export async function findDefinition(
     }
 
     // git the symbol at the cursor
-    const symbol = getSelectedSymbol(document, position);
+    const symbol = getSelectedSymbol(document, position, true);
 
     // if the cursor is within a (mask ...) or (enum ...) declaration, search for matching enum members
     const enumMembers = await findEnumOrMaskMembers(document, position, symbol, token, searchKind);

--- a/src/fracas/syntax.ts
+++ b/src/fracas/syntax.ts
@@ -606,7 +606,7 @@ export async function findKeywordDefinition(
         return [];
     }
 
-    const keyword = getSelectedSymbol(referencingDocument, documentSelection);
+    const keyword = referencingDocument.getText(documentSelection);
     if (!keyword.startsWith(KEYWORD_PREFIX)) {
         return [];
     }

--- a/src/test/fixture/ability-action-defines.frc
+++ b/src/test/fixture/ability-action-defines.frc
@@ -49,3 +49,50 @@
    )
   )
   
+  (define (ability-hero-shared-hit-actions:
+         #:res-a-add (res-a 0) ;; Amount of resource added for ability A
+         #:res-b-add (res-b 0) ;; Amount of resource added for ability B
+         #:res-c-add (res-c 0) ;; Amount of resource added for ability C
+         #:res-u-add (res-u 0) ;; Amount of resource added for ultimate ability
+         #:hit-tag (hit-tag *tag-cue.character.shared.hitspark.light*) ;; Gameplay tag used in this character's effects list to play hit vfx/audio
+         #:hit-tag-target (hit-tag-target *tag-cue.character.shared.hitspark.light.target*) ;; Gameplay tag used in the victim's effects list to play hit vfx/audio
+         #:camera-shake (camera-shake *camera-shake-small*) ;; Camera shake to play on a successful hit
+         #:self-actions (self-actions '()) ;; Additional actions you may want to run on self for a successful hit
+         #:contextual-actions (contextual-actions '()) ;; Additional actions you may want to run on the victim on a successful hit
+         #:other-actions (other-actions '()) ;; Any other actions you may want to run that are not explicitly targeted at self or victim
+         )
+  (append
+   other-actions
+   (list
+    (action-block-targeted:
+     #:targeting *targeting-self-instigator*
+     #:found-actions
+     (append
+      (list
+       (action-add-to-resources:
+        #:resources
+        (list
+         (resource-pair: #:type *res-a* #:amount res-a)
+         (resource-pair: #:type *res-b* #:amount res-b)
+         (resource-pair: #:type *res-c* #:amount res-c)
+         (resource-pair: #:type *res-u* #:amount res-u)
+         ))
+       (action-camera-shake: #:net-playback-mode *net-local-client* #:data camera-shake)
+       )
+      self-actions
+      )
+     )
+    (action-block-targeted:
+     #:targeting *targeting-contextual*
+     #:found-actions
+     (append
+      (list
+       (action-cue-tag: hit-tag #:target-tag hit-tag-target)
+       )
+      contextual-actions
+      )
+     )
+    )
+   )
+  )
+  

--- a/src/test/fixture/ability-data-defines.frc
+++ b/src/test/fixture/ability-data-defines.frc
@@ -1,0 +1,425 @@
+#lang fracas
+
+(import
+ fracas/utils/ws-math
+ fracas/utils/utils-collections
+ fracas/utils/utils-hashing
+ unreal-defines
+ ability-action-defines
+ ability-condition-defines
+ ability-keys-defines
+ ability-state-transition-defines
+ ability-state-transition-types
+
+ animation-defines
+ ability-state-transition-defines
+ condition-defines
+ spawn-actor-defines
+ damage-data-types
+ defense-effect-types
+ ui-particle-defines
+ movement-defines
+ targeting-types
+ resource-defines
+ input-types
+ value-defines
+
+ projectile-data-defines
+ status-effect-types
+ gameplay-tag-defines
+ event-defines
+ localization-defines
+
+ fracas/tags/char-shared-tags
+ fracas/tags/status-tags
+ )
+
+(provide (all-defined-out))
+
+;; DEPRECATED - we now use `gameplay-tag-data` to classify abilities, which is a tree-based data structure of tags (rather than a flat mask)
+(define-mask ability-flags
+  (
+   enable-debug
+   require-affinity
+   suppress-targeting ;; TODO: make state-based
+   show-directional-splat ;; TODO: make state-based
+   is-combo ;; TODO: probably not needed now that we have `ability-group`
+
+   is-attack
+   is-defense
+
+   is-basic
+   is-special
+   is-ultimate
+   )
+  )
+
+(define *final* 'final)
+(define *initial* 'initial)
+(define *state-a* 'state-a)
+(define *state-b* 'state-b)
+(define *state-c* 'state-c)
+(define *state-d* 'state-d)
+(define *exit* '_exit)
+
+;; represents the data used to populate a single state in the Ability's state machine
+(define-type ability-state-data
+  #:constructor-prefix internal-
+  (
+   (name key #:default *initial* #:constructor name->id)
+   (movement movement-modifier #:default *no-movement-or-rotation*) ;; used to modify movement during this state (e.g., stop movement, or double speed in the forward direction)
+   (activation-owned-tags (array gameplay-tag-data) #:default '()) ;; tags added to the ability's owner while this state is active
+
+   ;; Animation
+   (animation animation-type #:default *no-animation*)
+   (play-rate value #:default (value: 1) #:constructor value:)
+   (sequence sequence #:default (sequence-none:))
+   (pose blend-pose #:default (blend-pose:))
+   (look-ik look-ik #:default (look-ik-none:)) ;; look IK state that is valid for the duration of the state (automatically removed when the state exits)
+   (transition-in-duration float #:default 0.06)
+   (transition-out-duration float #:default 0.2)
+
+   ;; Actions
+   (enter-actions (array action-block) #:default '()) ;; actions run when the state is entered
+   (anim-actions (array action-block) #:default '()) ;; actions run when a notify within the state's montage is hit; if the notify has a specific name set on it, any actions within this list that have the matching `action-block.name` will fire, if the notify parameter is left blank, any unnamed `action-block`s will run
+   (exit-actions (array action-block) #:default '()) ;; actions run when the state is exited
+
+   ;; Transitions
+   (transitions (array ability-state-transition) #:default '()) ;; transitions are OR-ed and listed in priority order - the first transition in the array that evaluates to true will be taken
+
+   ;; Create an array of buttons used in the transitions so we know at runtime what buttons are "reserved" by this state/ability
+   (reserved-buttons (array button-state)
+                     #:default (λ (ht)
+                                  (define transitions (hash-ref ht 'transitions #f))
+                                  (if transitions
+                                      (apply
+                                       append
+                                       (for/list ([transition (value-field-value transitions)])
+                                         (for/list ([condition (condition->condition-list (@-> transition 'condition))]
+                                                    #:when (equal? (value-variant-option condition) 'button))
+                                           (@-> (value-variant-fields condition) 'state)
+                                           )))
+                                    '())
+                                  ))
+   )
+  )
+
+;; trimmed down version of `internal-ability-state-data` that removes the actionable-specific
+;; parameters that don't apply to characters (e.g., binding-animation)
+;; and adds shared ability transitions for early out to locomotion or exiting the ability from the timeline ending
+(define (ability-state-data:
+         #:name (name *initial*)
+         #:movement (movement *no-movement-or-rotation*)
+         #:activation-owned-tags (activation-owned-tags '())
+         #:montage (montage #f)
+         #:shared-animation (shared-animation #f)
+         #:sequence (sequence (sequence-none:))
+         #:pose (pose (blend-pose:))
+         #:look-ik (look-ik (look-ik-none:))
+         #:transition-in-duration (transition-in-duration 0.06)
+         #:transition-out-duration (transition-out-duration 0.2)
+         #:enter-actions (enter-actions '())
+         #:anim-actions (anim-actions '())
+         #:exit-actions (exit-actions '())
+         #:transitions (transitions '())
+         #:exit-ability-when-timeline-ends (exit-ability-when-timeline-ends #t) ;; by default, all ability states have an implicit `timeline-ended` transition (lower pri than all user-specified transitions) that will end the ability when the timeline completes unless this is set to #f
+         )
+  (internal-ability-state-data:
+   #:name name
+   #:movement movement
+   #:activation-owned-tags activation-owned-tags
+
+   #:animation
+   (cond
+    [montage
+     (animation-montage: montage)
+     ]
+    [shared-animation
+     (animation-shared: shared-animation)
+     ]
+    [else
+     *no-animation*
+     ]
+    )
+   #:sequence sequence
+   #:pose pose
+   #:look-ik look-ik
+   #:transition-in-duration transition-in-duration
+   #:transition-out-duration transition-out-duration
+
+   #:enter-actions enter-actions
+   #:anim-actions anim-actions
+   #:exit-actions exit-actions
+
+   ;; these transitions apply to ALL abilities and increase input responsiveness by
+   ;; ending abilities early for locomotion or other queued abilities;
+   ;; listed in priority order (designer-defined transitions first) -
+   ;; the first transition in the array that evaluates to true will be taken
+   #:transitions
+   (append
+    transitions
+    (list *locomotion-exit-ability-transition*)
+    (if exit-ability-when-timeline-ends
+        (list *timeline-ended-exit-ability-transition*)
+        '()
+      )
+    )
+   )
+  )
+
+;; UI-representation of this Ability
+(define-type ability-ui-info
+  #:constructor-prefix internal-
+  (
+   (display-name formatted-text)
+   (description formatted-text)
+   (image u-texture-2d) ;; image to display for this ability
+   (image-ready u-texture-2d) ;; alternate image to display when this ability is ready (cooldown + resource requirements met)
+   (ui-fx (array ui-fx-data)) ;; FX to call attention to an ability (e.g., once it becomes ready to use, or to remind the player that it's ready to use)
+   )
+  )
+(define (ability-ui-info:
+         #:display-name (display-name *loctext-empty*)
+         #:description (description *loctext-empty*)
+         #:image (image "")
+         #:image-ready (image-ready "")
+         #:ui-fx (ui-fx default-ui-particles-ability))
+  (internal-ability-ui-info:
+   #:display-name (format-text: display-name)
+   #:description (format-text: description)
+   #:image image
+   #:image-ready image-ready
+   #:ui-fx ui-fx
+   )
+  )
+
+(define *default-input-buffer-time* 0.2)
+
+;; defines what type of trigger will activate the ability, paired to a tag (see EGameplayAbilityTriggerSource)
+(define-enum trigger-source
+  (
+   (gameplay-event #:tool-tip "triggered from a gameplay event, will come with payload (won't add any tags to the character - useful for event-based ability triggers that are 'fire and forget', e.g., stagger or launch hit reactions)")
+   (owned-tag #:tool-tip "triggered if the ability's owner gets a tag added, and will continue to try to activate so long as the tag is present (useful for 'forcing' an ability to activate until the tag is removed, e.g., defeat)")
+   (owned-tag-added #:tool-tip "triggered if the ability's owner gets a tag added, triggered once whenever it's added (useful for state-based ability triggers that should stay active until the tag is removed, e.g., knockdown hit reaction)")
+   (owned-tag-present #:tool-tip "triggered if the ability's owner gets tag added, removed when the tag is removed (similar to `owned-tag-added`, but automatically cancels the ability when the tag is removed)")
+   )
+  )
+
+;; structure that defines how an ability will be triggered by external events (see FAbilityTriggerData)
+(define-type ability-trigger
+  (
+   (trigger-tag gameplay-tag-data) ;; the tag to respond to
+   (trigger-source trigger-source) ;; the type of trigger to respond to
+   )
+  )
+
+;; top level tag that all abilities share; useful for blocking/cancelling other abilities.
+(define *tag-ability*
+  (tag: 'ability "Root tag that all abilities share."))
+
+;; describes when/how the ability's costs and cooldowns will be applied to the owning actor
+(define-enum ability-commit-mode
+  (
+   (on-ability-activation #:tool-tip "ability cost and cooldown will be committed when ability is activated")
+   (on-ability-action #:tool-tip "resources/cooldown must be committed manually via an `action-commit`")
+   (on-ability-end #:tool-tip "ability cost and cooldown will be committed when ability is ended normally (not when cancelled)")
+   )
+  )
+(define *on-ability-activation* (enum ability-commit-mode on-ability-activation))
+(define *on-ability-action* (enum ability-commit-mode on-ability-action))
+(define *on-ability-end* (enum ability-commit-mode on-ability-end))
+
+;; ability-data is the "meat" of the ability-definition and contains all the data describing how to run the
+;; ability and defines all the states
+(define-type ability-data
+  #:constructor-prefix internal-
+  (
+   (commit ability-commit-mode #:default *on-ability-activation*)
+
+   (tags (array gameplay-tag-data) #:default (list *tag-ability*)) ;; this ability has these tags, which are used for identifying/classifying if this ability is affected by operations such as `cancel-abilities-with-tag` or `block-abilities-with-tag`
+   (triggers (array ability-trigger) #:default '()) ;; triggers to determine if this ability should execute in response to an event, or when tags are added to the owner
+   (cancel-abilities-with-tag (array gameplay-tag-data) #:default '()) ;; abilities with these tags are cancelled when this ability is executed
+   (block-abilities-with-tag (array gameplay-tag-data) #:default '()) ;; abilities with these tags are blocked while this ability is active
+   (activation-owned-tags (array gameplay-tag-data) #:default '()) ;; tags to apply to activating owner while this ability is active
+   (activation-required-tags (array gameplay-tag-data) #:default '()) ;; this ability can only be activated if the activating actor/component has ALL of these tags
+   (activation-blocked-tags (array gameplay-tag-data) #:default '()) ;; this ability is blocked if the activating actor/component has ANY of these tags
+   (source-required-tags (array gameplay-tag-data) #:default '()) ;; do not activate unless the source has ALL of these tags
+   (source-blocked-tags (array gameplay-tag-data) #:default '()) ;; do not activate if the source has ANY of these tags
+   (target-required-tags (array gameplay-tag-data) #:default '()) ;; do not activate unless the target has ALL of these tags
+   (target-blocked-tags (array gameplay-tag-data) #:default '()) ;; do not activate if the target has ANY of these tags
+
+   (combo-input-buffer-time float #:default *default-input-buffer-time*) ;; determines how long inputs to combo abilities will stay buffered; values < 0 are clamped to 0
+   (ability-input-buffer-time float #:default *default-input-buffer-time*) ;; determines how long inputs to other abilities will stay buffered; values < 0 are clamped to 0
+
+   (combat-focus-targeting (array targeting-data) #:default '()) ;; overrides the combat-info combat-focus list of targeting-datas
+   (trigger-defense-data defense-data #:default (defense-data-none:)) ;; This ability activates if incoming damage matches the defense-data.
+   (look-ik look-ik #:default (look-ik-disabled:)) ;; look IK state that is valid for the duration of the ability (automatically removed when the ability ends)
+   (approach approach-data #:default (approach-data-none:))
+
+   (states (array ability-state-data) #:default '())
+   (actions-map (map action-blocks #:key key) #:default '() #:constructor map-name->id) ;; @TODO: john_m JIRA-2169 workaround to allow actions to call other actions
+   (start-actions (array action-block) #:default '()) ;; action-blocks run when the ability activates
+   (end-actions (array action-block) #:default '()) ;; action-blocks run when the ability ends
+   )
+  )
+
+(define (ability-data:
+         #:commit (commit *on-ability-activation*)
+
+         #:tags (tags (list *tag-ability*))
+         #:triggers (triggers '())
+         #:cancel-abilities-with-tag (cancel-abilities-with-tag '())
+         #:block-abilities-with-tag (block-abilities-with-tag '())
+         #:activation-owned-tags (activation-owned-tags '())
+         #:activation-required-tags (activation-required-tags '())
+         #:activation-blocked-tags (activation-blocked-tags '())
+         #:source-required-tags (source-required-tags '())
+         #:source-blocked-tags (source-blocked-tags '())
+         #:target-required-tags (target-required-tags '())
+         #:target-blocked-tags (target-blocked-tags '())
+
+         #:flags (flags (mask ability-flags)) ;; DEPRECATED - flags that last for the full duration of the ability's activation
+         #:combo-input-buffer-time (combo-input-buffer-time *default-input-buffer-time*)
+         #:ability-input-buffer-time (ability-input-buffer-time *default-input-buffer-time*)
+
+         #:combat-focus-targeting (combat-focus-targeting '())
+         #:trigger-defense-data (trigger-defense-data (defense-data-none:))
+         #:look-ik (look-ik (look-ik-disabled:))
+         #:approach (approach (approach-data-none:))
+
+         #:states (states '())
+         #:actions-map (actions-map '())
+         #:start-actions (start-actions '())
+         #:end-actions (end-actions '())
+
+         #:can-activate-while-falling (can-activate-while-falling #f)
+         #:can-activate-while-sliding (can-activate-while-sliding #f)
+         #:can-activate-while-carrying (can-activate-while-carrying #f)
+         )
+  (internal-ability-data:
+   #:commit commit
+
+   #:tags tags
+   #:triggers triggers
+   #:cancel-abilities-with-tag cancel-abilities-with-tag
+   #:block-abilities-with-tag block-abilities-with-tag
+   #:activation-owned-tags activation-owned-tags
+   #:activation-required-tags activation-required-tags
+   #:activation-blocked-tags
+   (append
+    activation-blocked-tags
+    (filter values (list
+                    (if can-activate-while-falling #f *tag-character.movement.falling*)
+                    (if can-activate-while-sliding #f *tag-character.movement.custom.sliding*)
+                    (if can-activate-while-carrying #f *tag-character.block.abilities*)
+                    )))
+   #:source-required-tags source-required-tags
+   #:source-blocked-tags source-blocked-tags
+   #:target-required-tags target-required-tags
+   #:target-blocked-tags target-blocked-tags
+
+   #:combo-input-buffer-time combo-input-buffer-time
+   #:ability-input-buffer-time ability-input-buffer-time
+
+   #:combat-focus-targeting combat-focus-targeting
+   #:trigger-defense-data trigger-defense-data
+   #:look-ik look-ik
+   #:approach approach
+
+   #:states states
+   #:actions-map actions-map
+   #:start-actions start-actions
+   #:end-actions end-actions
+   )
+  )
+
+;; top-level Ability data object that wraps all data sub-objects, including the UI/input information about the ability,
+;; what resources it uses, and the actual data about the ability's states
+(define-type ability-definition
+  #:u-data-asset
+  (
+   (ui-info ability-ui-info #:default (ability-ui-info:))
+
+   (data ability-data #:default (ability-data:))
+
+   (priority int #:default 0) ;; higher values will interrupt active abilities of lower priority, ignoring queuing rules
+   (can-interrupt-self bool #:default #f) ;; can this ability can interrupt itself? t - override the default behaviour of ignoring new abilities with matching priority
+
+  (threat int #:default 10) ;; used for limiting # of abilities targeting an individual
+  (ignore-threat bool #:default #f) ;; if true, this ability will be allowed to activate even if it's threat will push the target's threat meter over max threat
+  (threat-exclusive bool #:default #f) ;; if true, blocks other abilities from activating on the target with this set to true; used for bosses
+
+   (charge-cost int #:default 0) ;; number of charges deducted when committing this ability (raw resource amount is (charge-cost * resource-per-charge)); will assert if used in an ability that doesn't have a corresponding resource
+   (charge-additional-resources (map float #:key resource-type) #:default '()) ;; additional resources required to activate the ability
+   (cooldown-seconds float #:default 0)
+   )
+  )
+
+;; used to declare key/value pairs for dictionaries of `ability-definition`s
+(define (ability-definition-entry keyname ability-definition)
+  (map-entry keyname ability-definition))
+
+;; belongs as a member to `ability-group` and uses the same ability keys as `ability-definition-entry`
+(define-type ability-group-entry
+  #:constructor-prefix internal-
+  (
+   (key key)
+   (condition ability-condition) ;; the condition under which this ability should be considered for selection (activation/display in the UI)
+   )
+  )
+
+;; shim constructor to allow deprecated #:conditions parameter and automatically converts 
+(define-syntax ability-group-entry:
+  (syntax-rules ()
+   [(ability-group-entry: #:key key #:condition condition)
+    (internal-ability-group-entry:
+     #:key (key: key)
+     #:condition condition)]
+   [(ability-group-entry: #:key key #:conditions conditions)
+    (internal-ability-group-entry:
+     #:key (key: key)
+     #:condition (ability-conditions->condition conditions))]
+   [(ability-group-entry: #:key key)
+    (internal-ability-group-entry:
+     #:key (key: key)
+     #:condition (ability-condition-true-value:))]
+   ))
+
+(define *ability-group-priority-base* 0)
+(define *ability-group-priority-held-item* 10)
+
+;; data structure that maps 1:1 to a button in the UI - intended only for abilities activated by user input
+(define-type ability-group
+  #:export-constructor
+  (
+   (default-ability ability-group-entry) ;; if no overrides are valid, this is the ability that will show up on the button
+   (override-abilities (array ability-group-entry) #:default '()) ;; order determines priority - conditions are evaluated every frame to decide if one of these abilities will replace the default-ability
+   (additional-abilities (array key) #:default '()) ;; additional abilities to load along with this ability-group that are used within state transitions
+   (tags (array gameplay-tag-data) #:default '()) ;; this ability-group has these tags, which are used for identifying/classifying this ability when the AI performs attacks (via `ai-ability-entry`)
+   (resource-key key #:default *key-none*) ;; resource pool that this ability utilizes
+
+   (priority int #:default *ability-group-priority-base*) ;; if multiple `ability-group` are loaded into a single slot, the highest priority one will win
+   (condition ability-condition #:default (ability-condition-true-value:)) ;; the condition under which this ability-group should be considered for input selection (activation/display in the UI) - this could be used to equip a "key" tool that only overrides the context/A/B/C inputs if you are within the range of a door by using the `ability-condition` to do a distance check to the door actor
+   )
+  )
+
+(define *action-block-edge-recovery*
+  (action-block-targeted:
+   #:targeting *targeting-self*
+   #:found-actions
+   (list
+    (action-lerp: #:data *lerp-data-edge-recovery*)
+    )
+   )
+  )
+
+(define-type ability-definitions
+  ((definitions (map ability-definition #:key key) #:constructor map-name->id)
+   (projectiles (map projectile-data #:key key))
+   (status-effects (map status-effect-data #:key key))
+   (defense-effects (map defense-data #:key key))
+   (ability-keys ability-keys)
+   (action-block-edge-recovery action-block #:default *action-block-edge-recovery*)
+   (shared-movement-modifiers shared-movement-modifiers #:default (shared-movement-modifiers:))
+   (global-actions-map (map action-blocks #:key key))
+   ))

--- a/src/test/fixture/ability-data-defines.frc
+++ b/src/test/fixture/ability-data-defines.frc
@@ -222,7 +222,7 @@
   (
    (on-ability-activation #:tool-tip "ability cost and cooldown will be committed when ability is activated")
    (on-ability-action #:tool-tip "resources/cooldown must be committed manually via an `action-commit`")
-   (on-ability-end #:tool-tip "ability cost and cooldown will be committed when ability is ended normally (not when cancelled)")
+   (on-ability-end #:tool-tip "ability cost and cooldown will be committed when ability is ended normally -- not when cancelled")
    )
   )
 (define *on-ability-activation* (enum ability-commit-mode on-ability-activation))

--- a/src/test/fixture/ability.frc
+++ b/src/test/fixture/ability.frc
@@ -46,3 +46,18 @@
    *self-destruct*
    )
   )
+
+(define ability-hero-amaya-basic-1-damage-hit-actions
+  (ability-hero-shared-hit-actions:
+   #:res-a-add *ability-hero-amaya-basic-res-gain-amount*
+   #:res-b-add *ability-hero-amaya-basic-res-gain-amount*
+   #:res-u-add *ability-hero-amaya-basic-1-res-u-gain-amount*
+   #:hit-tag *tag-cue.ability.basic.first.hitspark*
+   #:contextual-actions
+   (list
+    (action-flinch:)
+    (action-status-effect-add: #:key status-effect-key-silent-taunt)
+    ;;(action-knockback: #:distance 0.5)
+    )
+   )
+  )

--- a/src/test/fixture/collision-defines.frc
+++ b/src/test/fixture/collision-defines.frc
@@ -1,0 +1,129 @@
+#lang fracas
+
+(import
+ (utils ws-math)
+
+ unreal-defines
+ )
+
+(provide (all-defined-out))
+
+;; ------------------------------------------------------ ;;
+;;  Collision
+;; ------------------------------------------------------ ;;
+
+;; Corresponds to Project Settings -> Collision -> Preset
+;; @see DefaultEngine.ini
+(define-enum collision-preset
+  (
+   no-collision
+   block-all
+   player
+   pet
+   pawn
+   actionable ;; objects that the player can interact with @TODO: john_m split up into actionable-combat and actionable-interact
+   destructible ;; reserved for fragments of broken objects, purely visual physics objects
+   physics-actor
+   ;; overlap-combat @TODO: make another for projectiles/vortex that overlaps with actionables, players, pawns, etc. and blocked by environment
+   trigger ;; overlap-only with players
+   world-overlap ;; creates overlap events with world geometry (both static and dynamic) - useful for projectiles that can pass through walls (e.g., magic)
+   world-block ;; creates hit events with world geometry (both static and dynamic) - useful for projectiles that are blocked by walls (e.g., arrows)
+   projectile ;; creates overlap events with actors relevant to projectiles (incl. actionables, players, pawns)
+   overlap-only-pawn
+   )
+  )
+
+;; NOTE - This elements in this mask need to match the ECollisionChannel enum in EngineTypes.h and Data.h.
+;; That way we can use the bitmasks without converting.
+(define-mask phys-collision-channel
+  (
+   world-static
+   world-dynamic
+   pawn
+   visibility
+   camera
+   physics-body
+   vehicle
+   destructible
+
+   engine-1
+   engine-2
+   engine-3
+   engine-4
+   engine-5
+   engine-6
+
+   player ;; ECC_GameTraceChannel1
+   trigger ;; ECC_GameTraceChannel2
+   actionable ;; ECC_GameTraceChannel3
+   weapon ;; ECC_GameTraceChannel4
+   projectile ;; ECC_GameTraceChannel5
+   pushable ;; ECC_GameTraceChannel6
+   invisible-wall ;; ECC_GameTraceChannel7
+   pet ;; ECC_GameTraceChannel8
+   )
+  )
+
+(define *phys-channel-world-static* (mask phys-collision-channel world-static))
+(define *phys-channel-world-dynamic* (mask phys-collision-channel world-dynamic))
+(define *phys-channel-pawn* (mask phys-collision-channel pawn))
+(define *phys-channel-visibility* (mask phys-collision-channel visibility))
+(define *phys-channel-camera* (mask phys-collision-channel camera))
+(define *phys-channel-physics-body* (mask phys-collision-channel physics-body))
+(define *phys-channel-physics-vehicle* (mask phys-collision-channel vehicle))
+(define *phys-channel-physics-destructible* (mask phys-collision-channel destructible))
+(define *phys-channel-physics-player* (mask phys-collision-channel player))
+(define *phys-channel-physics-trigger* (mask phys-collision-channel trigger))
+(define *phys-channel-physics-actionable* (mask phys-collision-channel actionable))
+
+(define-enum phys-collision-response
+  (
+   ignore
+   overlap
+   block
+   )
+  )
+
+(define *phys-response-ignore* (enum phys-collision-response ignore))
+(define *phys-response-overlap* (enum phys-collision-response overlap))
+(define *phys-response-block* (enum phys-collision-response block))
+
+;; all shape dimensions are measured in METERS (engine-agnostic); conversion to engine units happens at runtime
+(define-variant shape
+  (box
+   (
+    (half-extents vector3 #:default (size:))
+    )
+   )
+  (capsule
+   (
+    (half-height float)
+    (radius float)
+    )
+   )
+  (sphere
+   (
+    (radius float)
+    )
+   )
+  (line ())
+  )
+
+(define-type collision-data
+  (
+   (draw-debug bool #:default #f) ;; enable to draw the collision shape at runtime - useful when prototyping and checking overlap sizes, or if you don't have art yet indicating the collision size
+   (shape shape)
+   (preset collision-preset)
+   )
+  )
+
+(define *collision-default-pawn*
+  (collision-data:
+   #:shape
+   (shape-capsule:
+    #:half-height 70
+    #:radius 40
+    )
+   #:preset (enum collision-preset pawn)
+   )
+  )

--- a/src/test/fixture/factions.frc
+++ b/src/test/fixture/factions.frc
@@ -1,0 +1,107 @@
+#lang fracas
+
+(import
+ unreal
+ )
+
+(provide (all-defined-out))
+
+(define-enum faction-type
+  ((invalid                  #:tool-tip "Special value to disable the faction override editor property")
+   (neutral                  #:tool-tip "Special value indicating no team")
+   (player-blue              #:tool-tip "Human player and their allies")
+   (player-red               #:tool-tip "Human player and their allies")
+   (npc                      #:tool-tip "Generic NPC team")
+   (npc-border-sunfire       #:tool-tip "Sunfire rebels found in the border")
+   (npc-border-crab          #:tool-tip "Magma crabs found in the border")
+   (npc-msf-beast            #:tool-tip "Forest Beasts found in MSF")
+   (npc-msf-beast-ally       #:tool-tip "Forest Beast Friends found in MSF")
+   (npc-msf-cultist          #:tool-tip "Bloodmoon Cultists found in MSF")
+   (npc-msf-spirits          #:tool-tip "Forest Spirits found in MSF")
+   )
+  )
+
+(define-enum faction-stance
+  (none
+   friendly
+   enemy))
+
+;;           neutral blue  red
+;; neutral                  
+;; blue              f     e
+;; red               e     f
+
+(define-type faction-pair
+  ((type-0 faction-type)
+   (type-1 faction-type)
+   ))
+
+(define-type faction-stances
+  ((stance faction-stance)
+   (pairs (array faction-pair))))
+
+(define-syntax-rule (stance: #:stance s (t0 t1) ...)
+  (faction-stances:
+   #:stance s
+   #:pairs (list (faction-pair: #:type-0 t0 #:type-1 t1) ...)))
+
+(define-type faction
+  ((name string #:default "")
+   (type faction-type)
+   (gizmo-path string #:default asset-faction-neutral-gizmo)))
+
+(define-type factions
+  ((factions (map faction #:key string))
+   (stances (array faction-stances))))
+
+(define *factions*
+  (factions:
+   #:factions
+   `((player-red . ,(faction: #:name "Red Team" #:type (enum faction-type player-red) #:gizmo-path asset-faction-red-gizmo))
+     (player-blue . ,(faction: #:name "Blue Team" #:type (enum faction-type player-blue) #:gizmo-path asset-faction-blue-gizmo))
+
+     (neutral . ,(faction: #:name "Neutral" #:type (enum faction-type neutral)))
+
+     (quirks . ,(faction: #:name "Quirks" #:type (enum faction-type neutral)))
+
+     (npc . ,(faction: #:name "NPCs" #:type (enum faction-type npc) #:gizmo-path asset-faction-red-gizmo))
+     (npc-border-sunfire . ,(faction: #:name "Sunfire Rebels" #:type (enum faction-type npc-border-sunfire) #:gizmo-path asset-faction-red-gizmo))
+     (npc-border-crab . ,(faction: #:name "Magma Crabs" #:type (enum faction-type npc-border-crab) #:gizmo-path asset-faction-red-gizmo))
+     (npc-msf-beast . ,(faction: #:name "Forest Beasts" #:type (enum faction-type npc-msf-beast) #:gizmo-path asset-faction-red-gizmo))
+     (npc-msf-beast-ally . ,(faction: #:name "Forest Friends" #:type (enum faction-type npc-msf-beast-ally) #:gizmo-path asset-faction-red-gizmo))
+     (npc-msf-cultist . ,(faction: #:name "Bloodmoon Cultists" #:type (enum faction-type npc-msf-cultist) #:gizmo-path asset-faction-red-gizmo))
+     (npc-msf-spirits . ,(faction: #:name "Forest Spirits" #:type (enum faction-type npc-msf-spirits) #:gizmo-path asset-faction-red-gizmo))
+     )
+   #:stances
+   (list
+    (stance: #:stance (enum faction-stance enemy) ((enum faction-type player-blue) (enum faction-type player-red)))
+    (stance: #:stance (enum faction-stance friendly) ((enum faction-type player-blue) (enum faction-type player-blue)))
+
+    (stance: #:stance (enum faction-stance friendly) ((enum faction-type player-red) (enum faction-type player-red)))
+
+    (stance: #:stance (enum faction-stance friendly) ((enum faction-type neutral) (enum faction-type neutral)))
+
+    (stance: #:stance (enum faction-stance enemy) ((enum faction-type npc) (enum faction-type player-blue)))
+
+    (stance: #:stance (enum faction-stance enemy) ((enum faction-type npc-border-sunfire) (enum faction-type player-blue)))
+    (stance: #:stance (enum faction-stance enemy) ((enum faction-type npc-border-sunfire) (enum faction-type npc-border-crab)))
+
+    (stance: #:stance (enum faction-stance enemy) ((enum faction-type npc-border-crab) (enum faction-type player-blue)))
+
+    (stance: #:stance (enum faction-stance enemy) ((enum faction-type npc-msf-beast) (enum faction-type player-blue)))
+    (stance: #:stance (enum faction-stance enemy) ((enum faction-type npc-msf-beast) (enum faction-type npc-msf-beast-ally)))
+    (stance: #:stance (enum faction-stance friendly) ((enum faction-type npc-msf-beast) (enum faction-type npc-msf-cultist)))
+    (stance: #:stance (enum faction-stance friendly) ((enum faction-type npc-msf-beast) (enum faction-type npc-msf-spirits)))
+
+    (stance: #:stance (enum faction-stance friendly) ((enum faction-type npc-msf-beast-ally) (enum faction-type player-blue)))
+    (stance: #:stance (enum faction-stance friendly) ((enum faction-type npc-msf-beast-ally) (enum faction-type npc-msf-beast-ally)))
+    (stance: #:stance (enum faction-stance enemy) ((enum faction-type npc-msf-beast-ally) (enum faction-type npc-msf-cultist)))
+
+    (stance: #:stance (enum faction-stance enemy) ((enum faction-type npc-msf-cultist) (enum faction-type player-blue)))
+
+    (stance: #:stance (enum faction-stance enemy) ((enum faction-type npc-msf-spirits) (enum faction-type player-blue)))
+    (stance: #:stance (enum faction-stance friendly) ((enum faction-type npc-msf-spirits) (enum faction-type npc-msf-cultist)))
+
+
+    )))
+

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -25,6 +25,7 @@ const rewardFrc = path.join(testFixtureDir, 'reward.frc');
 const factionsFrc = path.join(testFixtureDir, 'factions.frc');
 const collisionDefinesFrc = path.join(testFixtureDir, 'collision-defines.frc');
 const abilityFrc = path.join(testFixtureDir, 'ability.frc');
+const abilityDataDefinesFrc = path.join(testFixtureDir, 'ability-data-defines.frc');
 const abilityActionDefinesFrc = path.join(testFixtureDir, 'ability-action-defines.frc');
 
 suite("Editor Lib Tests", () => {
@@ -46,11 +47,22 @@ suite("Editor Lib Tests", () => {
 suite("Find Definition Tests", () => {
     vscode.window.showInformationMessage("Start findDefinition tests.");
 
+    test("findDefinition resolves an enum member at scope depth 2", async () => {
+        const { document } = await showFracasDocument(abilityDataDefinesFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(228,64)); // cursor within "on-ability-action" ability-commit-mode
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.enumMember, "type definition kind is not 'enumMember'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.EnumMember, "type completion kind is not 'EnumMember'");
+        assert.strictEqual(defs[0].symbol, "on-ability-action");
+        assert.strictEqual(defs[0].location.uri.fsPath, abilityDataDefinesFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(223, 4, 223, 21), "location of enum member is not correct");
+    });
+
     test("findDefinition resolves an enum member at scope depth 1", async () => {
         const { document } = await showFracasDocument(factionsFrc);
         const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(79, 46)); // cursor within "friendly" faction-stance
         assert.strictEqual(defs.length, 1, "single definition not found");
-        assert.strictEqual(defs[0].kind, FracasDefinitionKind.enumMember, "type definition kind is not 'enum'");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.enumMember, "type definition kind is not 'enumMember'");
         assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.EnumMember, "type completion kind is not 'EnumMember'");
         assert.strictEqual(defs[0].symbol, "friendly");
         assert.strictEqual(defs[0].location.uri.fsPath, factionsFrc);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -6,6 +6,7 @@ import path = require("path");
 import * as vscode from "vscode";
 import { getSelectedSymbol } from "../../editor-lib";
 import { 
+    findCompletions,
     findDefinition,
     FracasDefinition, 
     FracasDefinitionKind 
@@ -27,6 +28,8 @@ const collisionDefinesFrc = path.join(testFixtureDir, 'collision-defines.frc');
 const abilityFrc = path.join(testFixtureDir, 'ability.frc');
 const abilityDataDefinesFrc = path.join(testFixtureDir, 'ability-data-defines.frc');
 const abilityActionDefinesFrc = path.join(testFixtureDir, 'ability-action-defines.frc');
+
+
 
 suite("Editor Lib Tests", () => {
     vscode.window.showInformationMessage("Start editor lib tests.");
@@ -157,4 +160,53 @@ suite("Find Definition Tests", () => {
         assert.deepStrictEqual(defs[0].location.range, new vscode.Range(5, 3, 5, 11), "location of definition is not correct");
     });
 
+    suite("Auto-Completion Tests", () => {
+        vscode.window.showInformationMessage("Start findDefinition tests.");
+    
+        test("findCompletions resolves all mask members", async () => {
+            const { document } = await showFracasDocument(collisionDefinesFrc);
+            const completions = await findCompletions(document, new vscode.Position(67, 66)); // cursor just after "(mask phys-collision-channel "
+            assert.ok(completions, "findCompletions for (mask phys-collision-channel... returned null");
+            const expectedMembers = ["world-static", "world-dynamic", "pawn", "visibility", "camera", "physics-body", "vehicle", "destructible", "engine-1", "engine-2", "engine-3", "engine-4", "engine-5", "engine-6", "player", "trigger", "actionable", "weapon", "projectile", "pushable", "invisible-wall", "pet"];
+            for (const member of expectedMembers) {
+                assert.ok(completions.find(c => c.label === member), `Expected completion for ${member}`);
+            }
+            assert.strictEqual(completions.length, expectedMembers.length, "completion count incorrect");
+            for (const completion of completions) {
+                assert.strictEqual(completion.kind, vscode.CompletionItemKind.EnumMember, "completion kind is not 'EnumMember'");
+            }
+            const playerCompletion = completions.find(x => x.label === "player");
+            assert.strictEqual(playerCompletion?.documentation, "ECC_GameTraceChannel1", "completion documentation for (mask phys-collision-channel player) is not 'ECC_GameTraceChannel1'");
+        });
+    
+        test("findCompletions resolves all enum members", async () => {
+            const { document } = await showFracasDocument(abilityDataDefinesFrc);
+            const completions = await findCompletions(document, new vscode.Position(228,54)); // cursor just after "(enum ability-commit-mode "
+            assert.ok(completions, "findCompletions for enum ability-commit-mode `on-ability`... returned null");
+            const expectedMembers = ["on-ability-activation", "on-ability-action", "on-ability-end"];
+            for (const member of expectedMembers) {
+                assert.ok(completions.find(c => c.label === member), `Expected completion for ${member}`);
+            }
+            assert.strictEqual(completions.length, expectedMembers.length, "completion count incorrect");
+            for (const completion of completions) {
+                assert.strictEqual(completion.kind, vscode.CompletionItemKind.EnumMember, "completion kind is not 'EnumMember'");
+                assert.strictEqual(completion.documentation, "", "completion documentation is not ''");
+            }
+        });
+    
+        test("findCompletions filters non-matching enum members", async () => {
+            const { document } = await showFracasDocument(abilityDataDefinesFrc);
+            const completions = await findCompletions(document, new vscode.Position(228,66)); // cursor after "on-ability-a" within ability-commit-mode
+            assert.ok(completions, "findCompletions for enum ability-commit-mode `on-ability`... returned null");
+            const expectedMembers = ["on-ability-activation", "on-ability-action"];
+            for (const member of expectedMembers) {
+                assert.ok(completions.find(c => c.label === member), `Expected completion for ${member}`);
+            }
+            assert.strictEqual(completions.length, expectedMembers.length, "completion count incorrect");
+            for (const completion of completions) {
+                assert.strictEqual(completion.kind, vscode.CompletionItemKind.EnumMember, "completion kind is not 'EnumMember'");
+                assert.strictEqual(completion.documentation, "", "completion documentation is not ''");
+            }
+        });
+    });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -23,6 +23,7 @@ async function showFracasDocument(
 const testFixtureDir = (vscode.workspace.workspaceFolders || [])[0].uri.fsPath;
 const rewardFrc = path.join(testFixtureDir, 'reward.frc');
 const factionsFrc = path.join(testFixtureDir, 'factions.frc');
+const collisionDefinesFrc = path.join(testFixtureDir, 'collision-defines.frc');
 const abilityFrc = path.join(testFixtureDir, 'ability.frc');
 const abilityActionDefinesFrc = path.join(testFixtureDir, 'ability-action-defines.frc');
 
@@ -68,14 +69,25 @@ suite("Find Definition Tests", () => {
     });
 
     test("findDefinition resolves a mask definition", async () => {
-        const { document } = await showFracasDocument(factionsFrc);
-        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(59, 63)); // cursor within "faction-type"
+        const { document } = await showFracasDocument(collisionDefinesFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(67, 54)); // cursor within "phys-collision-channel"
         assert.strictEqual(defs.length, 1, "single definition not found");
-        assert.strictEqual(defs[0].kind, FracasDefinitionKind.enum, "type definition kind is not 'enum'");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.mask, "type definition kind is not 'mask'");
         assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Enum, "type completion kind is not 'Enum'");
-        assert.strictEqual(defs[0].symbol, "faction-type");
-        assert.strictEqual(defs[0].location.uri.fsPath, factionsFrc);
-        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(8, 13, 8, 25), "location of enum type is not correct");
+        assert.strictEqual(defs[0].symbol, "phys-collision-channel");
+        assert.strictEqual(defs[0].location.uri.fsPath, collisionDefinesFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(37, 13, 37, 35), "location of mask type is not correct");
+    });
+
+    test("findDefinition resolves a mask member at scope depth 1", async () => {
+        const { document } = await showFracasDocument(collisionDefinesFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(73, 79)); // cursor within "destructible"
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.maskMember, "type definition kind is not 'maskMember'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.EnumMember, "type completion kind is not 'EnumMember'");
+        assert.strictEqual(defs[0].symbol, "destructible");
+        assert.strictEqual(defs[0].location.uri.fsPath, collisionDefinesFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(46, 3, 46, 15), "location of mask member is not correct");
     });
 
     test("findDefinition resolves a named parameter", async () => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -50,6 +50,28 @@ suite("Editor Lib Tests", () => {
 suite("Find Definition Tests", () => {
     vscode.window.showInformationMessage("Start findDefinition tests.");
 
+    test("findDefinition resolves a named parameter", async () => {
+        const { document } = await showFracasDocument(abilityFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(42, 38)); // cursor within "#:net-playback-mode"
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.keyword, "type definition kind is not 'keyword'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Keyword, "type completion kind is not 'Keyword'");
+        assert.strictEqual(defs[0].symbol, "net-playback-mode");
+        assert.strictEqual(defs[0].location.uri.fsPath, abilityActionDefinesFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(26, 32, 26, 49), "location of named parameter is not correct");
+    });
+
+    test("findDefinition resolves a #:contextual-actions (JIRA-12970)", async () => {
+        const { document } = await showFracasDocument(abilityFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(55, 20)); // cursor within "#:contextual-actions"
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.keyword, "type definition kind is not 'keyword'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Keyword, "type completion kind is not 'Keyword'");
+        assert.strictEqual(defs[0].symbol, "contextual-actions");
+        assert.strictEqual(defs[0].location.uri.fsPath, abilityActionDefinesFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(60, 11, 60, 29), "location of named parameter is not correct");
+    });
+
     test("findDefinition resolves an enum member at scope depth 2", async () => {
         const { document } = await showFracasDocument(abilityDataDefinesFrc);
         const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(228,64)); // cursor within "on-ability-action" ability-commit-mode
@@ -103,17 +125,6 @@ suite("Find Definition Tests", () => {
         assert.strictEqual(defs[0].symbol, "destructible");
         assert.strictEqual(defs[0].location.uri.fsPath, collisionDefinesFrc);
         assert.deepStrictEqual(defs[0].location.range, new vscode.Range(46, 3, 46, 15), "location of mask member is not correct");
-    });
-
-    test("findDefinition resolves a named parameter", async () => {
-        const { document } = await showFracasDocument(abilityFrc);
-        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(42, 38)); // cursor within "#:net-playback-mode"
-        assert.strictEqual(defs.length, 1, "single definition not found");
-        assert.strictEqual(defs[0].kind, FracasDefinitionKind.keyword, "type definition kind is not 'parameter'");
-        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Keyword, "type completion kind is not 'Keyword'");
-        assert.strictEqual(defs[0].symbol, "net-playback-mode");
-        assert.strictEqual(defs[0].location.uri.fsPath, abilityActionDefinesFrc);
-        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(26, 32, 26, 49), "location of named parameter is not correct");
     });
 
     test("findDefinition resolves a field def", async () => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -22,6 +22,7 @@ async function showFracasDocument(
 
 const testFixtureDir = (vscode.workspace.workspaceFolders || [])[0].uri.fsPath;
 const rewardFrc = path.join(testFixtureDir, 'reward.frc');
+const factionsFrc = path.join(testFixtureDir, 'factions.frc');
 const abilityFrc = path.join(testFixtureDir, 'ability.frc');
 const abilityActionDefinesFrc = path.join(testFixtureDir, 'ability-action-defines.frc');
 
@@ -43,7 +44,40 @@ suite("Editor Lib Tests", () => {
 
 suite("Find Definition Tests", () => {
     vscode.window.showInformationMessage("Start findDefinition tests.");
-    
+
+    test("findDefinition resolves an enum member at scope depth 1", async () => {
+        const { document } = await showFracasDocument(factionsFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(79, 46)); // cursor within "friendly" faction-stance
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.enumMember, "type definition kind is not 'enum'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.EnumMember, "type completion kind is not 'EnumMember'");
+        assert.strictEqual(defs[0].symbol, "friendly");
+        assert.strictEqual(defs[0].location.uri.fsPath, factionsFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(25, 3, 25, 11), "location of enum member is not correct");
+    });
+
+    test("findDefinition resolves an enum definition", async () => {
+        const { document } = await showFracasDocument(factionsFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(59, 63)); // cursor within "faction-type"
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.enum, "type definition kind is not 'enum'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Enum, "type completion kind is not 'Enum'");
+        assert.strictEqual(defs[0].symbol, "faction-type");
+        assert.strictEqual(defs[0].location.uri.fsPath, factionsFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(8, 13, 8, 25), "location of enum type is not correct");
+    });
+
+    test("findDefinition resolves a mask definition", async () => {
+        const { document } = await showFracasDocument(factionsFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(59, 63)); // cursor within "faction-type"
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.enum, "type definition kind is not 'enum'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Enum, "type completion kind is not 'Enum'");
+        assert.strictEqual(defs[0].symbol, "faction-type");
+        assert.strictEqual(defs[0].location.uri.fsPath, factionsFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(8, 13, 8, 25), "location of enum type is not correct");
+    });
+
     test("findDefinition resolves a named parameter", async () => {
         const { document } = await showFracasDocument(abilityFrc);
         const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(42, 38)); // cursor within "#:net-playback-mode"


### PR DESCRIPTION
Improved handling of enums and masks:
* `F12` navigate to definition works for enum and mask type names and member names.
* You can auto-complete enum/mask type names after typing only one character
* auto-complete enum/mask member names now works properly, and works anywhere within the enum s-expression. In other words, I can press `<ctrl>-<space>` right after `(enum ability-commit-mode ` and all members of `ability-commit-mode` are presented as completions, whereas auto-complete previously required you type the first three characters of the enum member. 
* auto-complete resolves both enums declared as a list of naked identifiers (e.g. `(define-enum charge-state (empty filling full))`), and enums with metadata in parentheses (e.g. `(define-enum ability-commit-mode ( (on-ability-activation #:tool-tip ...`).
* auto-complete now resolves named function parameter keywords in addition to type field keywords. For example, pressing `<ctrl>-<space>` after `(item-weapon: #:` will present all named parameters of the `item-weapon:` function.
![image](https://user-images.githubusercontent.com/5162625/151431309-acea7502-a9b7-497b-a825-66879173081e.png)
* In addition, like enums and masks, you are no longer required to type any letters except the keyword prefix `#:` to get auto-complete suggestions for all parameter names.

