### PR TITLE
JIRA-15731 As a fracas user, I can "go to definition" on `struct`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "Wonderstorm",
     "displayName": "Fracas",
     "description": "Syntax highlighting, code navigation, document formatting, and REPL support for the Fracas and Racket programming languages",
-    "version": "0.1.23",
+    "version": "0.1.24",
     "enabledApiProposals": [
         "textSearchProvider",
         "findTextInFiles"
@@ -13,7 +13,7 @@
         "url": "https://github.com/WSStudios/vscode-fracas.git"
     },
     "engines": {
-        "vscode": "^1.61.0"
+        "vscode": "^1.67.0"
     },
     "categories": [
         "Programming Languages",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,7 +94,7 @@ async function configurationChanged() {
     }
 }
 
-let diagnosticCollection: vscode.DiagnosticCollection;
+// let diagnosticCollection: vscode.DiagnosticCollection;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     // Each file has one output terminal and one repl
@@ -131,14 +131,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.workspace.onDidSaveTextDocument(async document => {
         if (document && document.languageId === "fracas") {
             // diagnosticCollection.clear();
-            const range = document.getWordRangeAtPosition(
-                vscode.window.activeTextEditor?.selection.anchor ?? new vscode.Position(0,0),
-                /[#:\w\-+*.>/]+/);
+            // const range = document.getWordRangeAtPosition(
+            //     vscode.window.activeTextEditor?.selection.anchor ?? new vscode.Position(0,0),
+            //     /[#:\w\-+*.>/]+/);
             
-            if (range) {
-                const diagnostic = new vscode.Diagnostic(range, "Why'd you fuck this up?", DiagnosticSeverity.Warning);
-                diagnosticCollection.set(document.uri, [diagnostic]);
-            }
+            // if (range) {
+            //     const diagnostic = new vscode.Diagnostic(range, "Why'd you fuck this up?", DiagnosticSeverity.Warning);
+            //     diagnosticCollection.set(document.uri, [diagnostic]);
+            // }
             
             await com.precompileFracasFile(document);
             _maybeUpdateStringTables([document.uri]);
@@ -171,8 +171,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         reg("ue4OpenAsset", () => ue4.ue4OpenEditorsForAssets()));
 
     // Register FRACAS language support
-    diagnosticCollection = vscode.languages.createDiagnosticCollection('fracas');
-    context.subscriptions.push(diagnosticCollection);
+    // diagnosticCollection = vscode.languages.createDiagnosticCollection('fracas');
+    // context.subscriptions.push(diagnosticCollection);
     context.subscriptions.push(
         vscode.languages.registerDefinitionProvider(fracasDocumentFilter, new FracasDefinitionProvider()));
     context.subscriptions.push(

--- a/src/fracas/syntax-regex.ts
+++ b/src/fracas/syntax-regex.ts
@@ -14,7 +14,7 @@ export const RX_COMMENT = ';;?\\s*(.*)\\s*$';
 export const RX_EXCEPT_OUT = '\\(except-out\\s+\\(\\s*all-defined-out\\s*\\)';
 export const RX_EXCEPT_OUT_EXPR = `${RX_EXCEPT_OUT}[\\s\\n]+([^\\)]+)\\)`;
 export const RX_IDENTIFIER = `(${RX_CHAR_IDENTIFIER}+)`
-export const RX_SYMBOLS_DEFINE = 'define-enum|define-game-data|define-key|define-text|define-string-table|define-mask|define-type-optional|define-syntax|define-syntax-rule|define-type|define-variant|define|define-list';
+export const RX_SYMBOLS_DEFINE = 'define-enum|define-game-data|define-key|define-text|define-string-table|define-mask|define-type-optional|define-syntax|define-syntax-rule|define-type|struct|define-variant|define|define-list';
 /**
  * A regex that matches an expression within the body of a "(provide ...", one of the forms:
  * (provide (all-defined-out))

--- a/src/fracas/syntax.ts
+++ b/src/fracas/syntax.ts
@@ -103,6 +103,8 @@ export function definitionKind(defToken: string): FracasDefinitionKind {
             return FracasDefinitionKind.syntax;
         case 'define-type':
             return FracasDefinitionKind.type;
+        case 'struct':
+            return FracasDefinitionKind.type;
         case 'define-variant':
             return FracasDefinitionKind.variant;
         case 'define':

--- a/syntaxes/fracas.tmLanguage.json
+++ b/syntaxes/fracas.tmLanguage.json
@@ -58,7 +58,7 @@
       "patterns": [
         {
           "name": "keyword.define.fracas",
-          "match": "(?x) (?<=[\\(|\\{|\\[]) (define-enum|define-game-data|define-key|define-text|define-string-table|define-mask|define-type-optional|define-syntax|define-syntax-rule|define-type|define-variant|define|define-list) (?=[\\)|\\}|\\]|\\s])\n"
+          "match": "(?x) (?<=[\\(|\\{|\\[]) (define-enum|define-game-data|define-key|define-text|define-string-table|define-mask|define-type-optional|define-syntax|define-syntax-rule|define-type|struct|define-variant|define|define-list) (?=[\\)|\\}|\\]|\\s])\n"
         }
       ]
     },


### PR DESCRIPTION
Allows us to use the `Go To Definition` feature on a Racket `struct`

Slack thread describing how to build the VS Code plugin:
https://wonderstorm.slack.com/archives/D9SJ13MHN/p1639533080034000