### PR TITLE
Add util function to exec a process with a toast notif and cancellation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
     "name": "vsc-fracas",
-    "version": "0.1.23",
+    "version": "0.1.24",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vsc-fracas",
-            "version": "0.1.23",
+            "version": "0.1.24",
             "dependencies": {
                 "@types/ini": "^1.3.31",
                 "@types/tmp": "^0.2.3",
                 "ini": "^2.0.0",
                 "tmp": "^0.2.1",
                 "tmp-promise": "^3.0.3",
+                "tree-kill": "1.2.2",
                 "vscode-languageclient": "^7.0.0"
             },
             "devDependencies": {
@@ -31,7 +32,7 @@
                 "vscode-test": "^1.5.2"
             },
             "engines": {
-                "vscode": "^1.61.0"
+                "vscode": "^1.67.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -2678,6 +2679,14 @@
                 "node": "*"
             }
         },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "bin": {
+                "tree-kill": "cli.js"
+            }
+        },
         "node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -4747,6 +4756,11 @@
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
             "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
             "dev": true
+        },
+        "tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
         },
         "tslib": {
             "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -144,11 +144,17 @@
                     "markdownDescription": "Paths to search for Racket collections. Relative to `#vscode-fracas.general.projectWorkspaceFolder#`",
                     "order": 1
                 },
+                "vscode-fracas.general.precompileOnSave": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Automatically compile fracas whenever a file is saved. Pre-compilation uses CPU, but makes the `Run file in terminal` command start more quickly.",
+                    "order": 2
+                },
                 "vscode-fracas.formatting.indentComments": {
                     "type": "boolean",
                     "default": true,
                     "markdownDescription": "If true, comment lines will be indented possibly messing with any deliberate comment layout",
-                    "order": 2
+                    "order": 3
                 },
                 "vscode-fracas.localization.stringTableRegistryFile": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
             {
                 "command": "vscode-fracas.runFile",
                 "title": "Racket: Run file in terminal",
+                "enablement": "vscode-fracas.ready",
                 "icon": {
                     "light": "images/run.svg",
                     "dark": "images/run.svg"
@@ -238,11 +239,13 @@
             },
             {
                 "command": "vscode-fracas.executeSelectionInRepl",
-                "title": "Racket: Execute selection in REPL"
+                "title": "Racket: Execute selection in REPL",
+                "enablement": "vscode-fracas.ready"
             },
             {
                 "command": "vscode-fracas.openRepl",
-                "title": "Racket: Open the REPL for the current file"
+                "title": "Racket: Open the REPL for the current file",
+                "enablement": "vscode-fracas.ready"
             },
             {
                 "command": "vscode-fracas.showOutputTerminal",
@@ -250,19 +253,23 @@
             },
             {
                 "command": "vscode-fracas.compileSelectedFracasObject",
-                "title": "Fracas: Compile Selected Object"
+                "title": "Fracas: Compile Selected Object",
+                "enablement": "vscode-fracas.ready"
             },
             {
                 "command": "vscode-fracas.recompileFracasObject",
-                "title": "Fracas: Recompile Previous Object"
+                "title": "Fracas: Recompile Previous Object",
+                "enablement": "vscode-fracas.ready"
             },
             {
                 "command": "vscode-fracas.makeStringTableImport",
-                "title": "Fracas: Make String Table CPP"
+                "title": "Fracas: Make String Table CPP",
+                "enablement": "vscode-fracas.ready"
             },
             {
                 "command": "vscode-fracas.precompileFracasFile",
-                "title": "Fracas: Precompile File"
+                "title": "Fracas: Precompile File",
+                "enablement": "vscode-fracas.ready"
             },
             {
                 "command": "vscode-fracas.ue4OpenAsset",

--- a/package.json
+++ b/package.json
@@ -397,6 +397,7 @@
         "ini": "^2.0.0",
         "tmp": "^0.2.1",
         "tmp-promise": "^3.0.3",
+        "tree-kill": "1.2.2",
         "vscode-languageclient": "^7.0.0"
     }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -155,14 +155,15 @@ export async function precompileFracasFile(frcDoc: vscode.TextDocument | undefin
             const coresUsed = Math.ceil(os.cpus().length / 2); // use half the cores available to prevent starvation
             const ninjaCmd = `"${ninja}" -j ${coresUsed} -f "${precompileNinjaFile}"`;
             config.fracasOut.appendLine(`Precompiling fracas files with ${coresUsed} cores because ${frcDoc.fileName} has changed: ${ninjaCmd}`);
-    
+
             const execOpts = {
                 workingDir: projectFolder.uri.fsPath,
                 showErrors: false,
-                timeoutMillis: 240_000
+                timeoutMillis: 240_000,
+                lowPriority: true,
+                serializedExecutionKey: "precompileFracasFile"
             };
             await utils.execShellWithProgress(ninjaCmd, "Compiling Fracas", execOpts);
-
         } finally {
             // re-enable fracas commands
             vscode.commands.executeCommand('setContext', 'vscode-fracas.ready', true);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,3 +1,4 @@
+import * as os from "os";
 import * as path from "path";
 import * as tmpPromise from "tmp-promise";
 import { TextEncoder } from "util";
@@ -95,7 +96,9 @@ export async function makeStringTableImport(): Promise<void> {
         });
 
         config.fracasOut.appendLine(`Generating ${textFrcFiles.length} text source files into "${stringTableCpp}"`);
-        await utils.execShell(`${racket} ../fracas/lib/fracas/make-string-table-import.rkt -- ${csvFiles.join(" ")}`);
+
+        const cmd = `${racket} ../fracas/lib/fracas/make-string-table-import.rkt -- ${csvFiles.join(" ")}`;
+        await utils.execShellWithProgress(cmd, `Generating ${path.basename(stringTableCpp)}`);
     }
 }
 
@@ -103,8 +106,9 @@ export async function compileFracasObject(filePath: string, fracasObject: string
     const racket = config.getRacketShellCmd();
     if (fracasObject && filePath && racket) {
         vscode.window.activeTextEditor?.document?.save();
-        const cmd = `(require fracas/make-asset) (enter! (file "${filePath}")) (define-asset-impl: #:value ${fracasObject} #:value-name (quote ${fracasObject}) #:key (key: ${fracasObject}))`;
-        await utils.execShell(`${racket} -e "${cmd.replace(/"/g, '\\"')}"`);
+        const racketExpr = `(require fracas/make-asset) (enter! (file "${filePath}")) (define-asset-impl: #:value ${fracasObject} #:value-name (quote ${fracasObject}) #:key (key: ${fracasObject}))`;
+        const cmd = `${racket} -e "${racketExpr.replace(/"/g, '\\"')}"`
+        await utils.execShellWithProgress(cmd, `Compiling ${fracasObject}`);
     }
 }
 
@@ -128,30 +132,41 @@ export async function precompileFracasFile(frcDoc: vscode.TextDocument | undefin
 
     // if there is a fracas document, precompile it
     if (frcDoc && frcDoc.languageId === "fracas") {
-        frcDoc.save(); // save the document before precompiling
-
-        const ninja = config.getNinja();
-
-        // Invoke ninja to update all precompiled zo file dependencies
-        const precompileNinjaFile = path.join("build", "build_precompile.ninja");
-        const projectFolder = config.getProjectFolder();
-
         try {
-            // make sure build_precompile.ninja exists. Users with pre-built binaries may not have this file
-            await vscode.workspace.fs.stat(vscode.Uri.joinPath(projectFolder.uri, precompileNinjaFile));
-        } catch {
-            config.fracasOut.appendLine("Skip precompiling because build_precompile.ninja does not exist");
-            return;
-        }
+            // disable fracas commands until precompilation is done
+            vscode.commands.executeCommand('setContext', 'vscode-fracas.ready', false);
 
-        const ninjaCmd = `"${ninja}" -f "${precompileNinjaFile}"`;
-        config.fracasOut.appendLine(`Precompiling fracas files because ${frcDoc.fileName} has changed: ${ninjaCmd}`);
-        const execOpts = {
-            workingDir: projectFolder.uri.fsPath,
-            showErrors: false,
-            timeoutMillis: 240_000
-        };
-        await utils.execShell(ninjaCmd, execOpts);
+            frcDoc.save(); // save the document before precompiling
+    
+            const ninja = config.getNinja();
+    
+            // Invoke ninja to update all precompiled zo file dependencies
+            const precompileNinjaFile = path.join("build", "build_precompile.ninja");
+            const projectFolder = config.getProjectFolder();
+    
+            try {
+                // make sure build_precompile.ninja exists. Users with pre-built binaries may not have this file
+                await vscode.workspace.fs.stat(vscode.Uri.joinPath(projectFolder.uri, precompileNinjaFile));
+            } catch {
+                config.fracasOut.appendLine("Skip precompiling because build_precompile.ninja does not exist");
+                return;
+            }
+    
+            const coresUsed = Math.ceil(os.cpus().length / 2); // use half the cores available to prevent starvation
+            const ninjaCmd = `"${ninja}" -j ${coresUsed} -f "${precompileNinjaFile}"`;
+            config.fracasOut.appendLine(`Precompiling fracas files with ${coresUsed} cores because ${frcDoc.fileName} has changed: ${ninjaCmd}`);
+    
+            const execOpts = {
+                workingDir: projectFolder.uri.fsPath,
+                showErrors: false,
+                timeoutMillis: 240_000
+            };
+            await utils.execShellWithProgress(ninjaCmd, "Compiling Fracas", execOpts);
+
+        } finally {
+            // re-enable fracas commands
+            vscode.commands.executeCommand('setContext', 'vscode-fracas.ready', true);
+        }
     }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -148,3 +148,9 @@ export function shouldFormatterIndentComments(): boolean {
         .getConfiguration("vscode-fracas.formatting")
         .get<boolean>("indentComments") ?? true;
 }
+
+export function shouldPrecompileOnSave(): boolean {
+    return vscode.workspace
+        .getConfiguration("vscode-fracas.general")
+        .get<boolean>("precompileOnSave") ?? true;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,7 +103,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const terminals: Map<string, vscode.Terminal> = new Map();
     const repls: Map<string, vscode.Terminal> = new Map();
 
-    // precompile fracas every time a file is saved
     function _maybeUpdateStringTables(uris: readonly vscode.Uri[]): void {
         if (uris.some(uri => {
             const fileName = path.basename(uri.path);
@@ -112,7 +111,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             com.makeStringTableImport();
         }
     }
-
     // vscode.workspace.onDidChangeTextDocument(changeEvent => {
     //     const document = changeEvent.document;
     //     if (document.languageId === 'fracas') {
@@ -127,7 +125,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     //     }
     // });
     
-    vscode.workspace.fs.stat
+    // Update string tables and precompile fracas every time a file is saved
     vscode.workspace.onDidSaveTextDocument(async document => {
         if (document && document.languageId === "fracas") {
             // diagnosticCollection.clear();
@@ -140,7 +138,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             //     diagnosticCollection.set(document.uri, [diagnostic]);
             // }
             
-            // await com.precompileFracasFile(document);
+            await com.precompileFracasFile(document);
             _maybeUpdateStringTables([document.uri]);
         }
     });
@@ -200,4 +198,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     await configurationChanged(); // Start language server.
     watchProjectConfig(); // watch for wonderstorm .cfg file changes
     vscode.workspace.onDidChangeConfiguration(configurationChanged); // watch VS code config changes
+
+    vscode.commands.executeCommand('setContext', 'vscode-fracas.ready', true);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import {
     fracasOut,
     loadProjectConfig,
     setFormatterScript,
+    shouldPrecompileOnSave,
     watchProjectConfig
 } from "./config";
 import { withRacket } from "./utils";
@@ -138,7 +139,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             //     diagnosticCollection.set(document.uri, [diagnostic]);
             // }
             
-            await com.precompileFracasFile(document);
+            if (shouldPrecompileOnSave()) {
+                await com.precompileFracasFile(document);
+            }
             _maybeUpdateStringTables([document.uri]);
         }
     });

--- a/src/fracas/syntax-regex.ts
+++ b/src/fracas/syntax-regex.ts
@@ -44,8 +44,8 @@ export function anyDefineRx(): string {
 
 export function anyDefineSymbolRx(symbol: string, searchKind = SearchKind.wholeMatch): string {
     return searchKind === SearchKind.wholeMatch ?
-        `(?<=[${RX_CHARS_OPEN_PAREN}])\\s*(${RX_SYMBOLS_DEFINE})\\s*[${RX_CHARS_OPEN_PAREN}]?\\s*(${escapeForRegEx(symbol)})(?!${RX_CHAR_IDENTIFIER}|${RX_CHARS_CLOSE_PAREN})` :
-        `(?<=[${RX_CHARS_OPEN_PAREN}])\\s*(${RX_SYMBOLS_DEFINE})\\s*[${RX_CHARS_OPEN_PAREN}]?\\s*(${escapeForRegEx(symbol)}${RX_CHAR_IDENTIFIER}*)(?!${RX_CHARS_CLOSE_PAREN})`;
+        `(?<=[${RX_CHARS_OPEN_PAREN}])\\s*(${RX_SYMBOLS_DEFINE})\\s*[${RX_CHARS_OPEN_PAREN}]?\\s*(${escapeForRegEx(symbol)})(?!${RX_CHAR_IDENTIFIER})` :
+        `(?<=[${RX_CHARS_OPEN_PAREN}])\\s*(${RX_SYMBOLS_DEFINE})\\s*[${RX_CHARS_OPEN_PAREN}]?\\s*(${escapeForRegEx(symbol)}${RX_CHAR_IDENTIFIER}*))`;
 }
 
 export function definePartialSymbolRx(symbol: string): string {

--- a/src/test/fixture/ability-action-defines.frc
+++ b/src/test/fixture/ability-action-defines.frc
@@ -1,5 +1,5 @@
 #lang fracas
-
+(define-key *key-none*)
 ;; Actions are always performed in the order they appear in the arrays below
 (define-variant action-block
   #:u-data-asset
@@ -95,4 +95,22 @@
     )
    )
   )
-  
+
+  (define-type damage-data) # forward decl
+
+(define-variant action
+  #:export-constructor
+  ;; If run from an ability where `ability-data.commit` is set to `(enum ability-commit-mode on-ability-action)`,
+  ;; this action can be used to delay deducting costs or starting the cooldown until a specific state or point in the animation (e.g., by use in #:anim-actions).
+  ;; This is useful for resources from consumables, since you don't want to punish the player and spend their resources unless they get the benefit from the ability.
+  ;; E.g., if the player gets hit-reacted/interrupted while using a jelly tart before the heal effect is applied, it wouldn't use your consumable
+  ;; if the `action-commit` was on the same animation frame as the heal effect.
+  ;; Targets are ignored for this action, and it is applied only to the actor executing the action
+  ;; (otherwise, you could have players targeting one another and committing each other's abilites).
+  (commit-ability
+   ((mode commit #:default (mask commit cost cooldown)))) ;; default is to commit cost and cooldown together
+
+  ;; applies a gameplay effect that damages all targets
+  (damage
+   ((data damage-data)))
+)

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -97,6 +97,23 @@ suite("Provide Tests", () => {
 suite("Find Definition Tests", () => {
     vscode.window.showInformationMessage("Start findDefinition tests.");
 
+    test("findDefinition ignores a forward declaration", async () => {
+        const { document } = await showFracasDocument(abilityActionDefinesFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(114, 14)); // cursor within "((data damage-data)))"
+        assert.strictEqual(defs.length, 0, "findDefinition should ignore a forward declaration");
+    });
+
+    test("findDefinition resolves a define-key", async () => {
+        const { document } = await showFracasDocument(abilityDataDefinesFrc);
+        const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(398, 35)); // cursor within "*key-none*"
+        assert.strictEqual(defs.length, 1, "single definition not found");
+        assert.strictEqual(defs[0].kind, FracasDefinitionKind.key, "type definition kind is not 'key'");
+        assert.strictEqual(defs[0].completionKind, vscode.CompletionItemKind.Variable, "type completion kind is not 'Variable'");
+        assert.strictEqual(defs[0].symbol, "*key-none*", "symbol is not '*key-none*'");
+        assert.strictEqual(defs[0].location.uri.fsPath, abilityActionDefinesFrc);
+        assert.deepStrictEqual(defs[0].location.range, new vscode.Range(1, 12, 1, 22), "location of key is not correct");
+    });
+
     test("findDefinition resolves a named parameter", async () => {
         const { document } = await showFracasDocument(abilityFrc);
         const defs: FracasDefinition[] = await findDefinition(document, new vscode.Position(42, 38)); // cursor within "#:net-playback-mode"

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -7,6 +7,7 @@ export function run(): Promise<void> {
     const mocha = new Mocha({
         ui: "tdd",
         color: true,
+        timeout: 5000,
     });
 
     const testsRoot = path.resolve(__dirname, "..");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,17 +52,6 @@ export function execShell(
                 }
                 
                 resolve(stdout);
-            }).on("exit", (code, signal) => {
-                const message = `Command exited with code ${code} signal ${signal}: '${cmd}'`;
-                fracasOut.appendLine(message);
-                
-                if (options.serializedExecutionKey) {
-                    runningProcesses.delete(options.serializedExecutionKey);
-                }
-
-                if (code !== 0) {
-                    reject(message);
-                }
             });
 
         // keep track of this execution

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,9 +91,9 @@ export function execShellWithProgress(
         cancellable: true,
         title: title
     }, async (progress, token) => {
-        progress.report({  message: "doin it now" });
+        progress.report({  message: "Working..." });
         const output = await execShell(cmd, options, token);
-        progress.report({ message: "all done yo" });
+        progress.report({ message: "Done!" });
         return output;
     }).then(undefined, (error) => error );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import * as kill from "tree-kill";
+import * as os from "os"
 import * as vscode from "vscode";
 import * as cp from "child_process";
 import { fracasOut, getProjectDir, getRacket, getRacketShellCmd } from "./config";
@@ -8,8 +10,11 @@ export interface ExecOptions {
     workingDir?: string;
     showErrors: boolean;
     timeoutMillis: number;
+    lowPriority?: boolean;
+    serializedExecutionKey?: string; // unique id for the command. If a previous instance is still running, cancel it before executing the new one.
 }
 
+const runningProcesses: Map<string, cp.ChildProcess> = new Map();
 export function execShell(
     cmd: string,
     options: ExecOptions = { showErrors: true, workingDir: getProjectDir(), timeoutMillis: 60_000 },
@@ -17,26 +22,65 @@ export function execShell(
 ) : Promise<string> {
     fracasOut.appendLine(`From working dir: '${options.workingDir}'`);
     fracasOut.appendLine(`Executing: '${cmd}'`);
+
+    // kill previous process if it is still running
+    if (options.serializedExecutionKey) {
+        const previousProcess = runningProcesses.get(options.serializedExecutionKey);
+        if (previousProcess) {
+            if (previousProcess.exitCode === null) {
+                kill(previousProcess.pid);
+            }
+        }
+    }
+    
+    // launch the process
     return new Promise<string>((resolve, reject) => {
         const child = cp.exec(cmd,
             { cwd: options.workingDir, timeout: options.timeoutMillis },
-            (err, out) => {
-                if (err) {
+            (error, stdout) => {
+                if (error) {
                     if (options.showErrors) {
-                        vscode.window.showErrorMessage(err.message + "\n" + out);
+                        vscode.window.showErrorMessage(error.message + "\n" + stdout);
                     }
                     fracasOut.appendLine(`Command failed '${cmd}':`);
-                    fracasOut.appendLine(`${err.name}: ${err.message}`);
-                    if (err.stack) {
-                        fracasOut.appendLine(err.stack);
+                    fracasOut.appendLine(`${error.name}: ${error.message}`);
+                    if (error.stack) {
+                        fracasOut.appendLine(error.stack);
                     }
-                    return reject(err);
+                    
+                    reject(error);
                 }
-                return resolve(out);
+                
+                resolve(stdout);
+            }).on("exit", (code, signal) => {
+                const message = `Command exited with code ${code} signal ${signal}: '${cmd}'`;
+                fracasOut.appendLine(message);
+                
+                if (options.serializedExecutionKey) {
+                    runningProcesses.delete(options.serializedExecutionKey);
+                }
+
+                if (code !== 0) {
+                    reject(message);
+                }
             });
 
+        // keep track of this execution
+        if (options.serializedExecutionKey) {
+            runningProcesses.set(options.serializedExecutionKey, child);
+        }
+        
         // Kill the child process if the token is cancelled
-        token?.onCancellationRequested(() => child.kill());
+        token?.onCancellationRequested(() => { 
+            if (child.exitCode === null) { 
+                kill(child.pid); 
+            } 
+        });
+        
+        // nice the process if it's low priority
+        if (options.lowPriority) {
+            os.setPriority(child.pid, os.constants.priority.PRIORITY_BELOW_NORMAL);
+        }
 
         // if an input is given, pipe it to the child process
         if (options.input && child.stdin) {
@@ -58,11 +102,11 @@ export function execShellWithProgress(
         cancellable: true,
         title: title
     }, async (progress, token) => {
-        progress.report({  increment: 25 });
+        progress.report({  message: "doin it now" });
         const output = await execShell(cmd, options, token);
-        progress.report({ increment: 100 });
+        progress.report({ message: "all done yo" });
         return output;
-    });
+    }).then(undefined, (error) => error );
 }
 
 export function kebabCaseToPascalCase(input: string): string


### PR DESCRIPTION
Updates to precompile:
- Pops up a toast/progress notification with the option to cancel
<img width="422" alt="cancel precompile" src="https://user-images.githubusercontent.com/5162625/181656657-d7ada1a9-6b3e-480c-821f-392a2f8ef5a4.png" />
- Added a setting to disable automatic precompilation:
<img width="422" alt="Disable Precompile" src="https://user-images.githubusercontent.com/5162625/181656903-eb16d172-5c6e-4051-ac01-c5a033727994.png" />
- Serialize invocations of precompilation: starting a new precompile kills the previous precompile.
- Run the ninja.exe process at low priority
- Constrain ninja to use at most half the machine's cores

Fix goto-definition for `define-key`
